### PR TITLE
feature: Show a root directory in a directory explorer

### DIFF
--- a/frontend/src/pages/directories/DirectoryEditPage.tsx
+++ b/frontend/src/pages/directories/DirectoryEditPage.tsx
@@ -8,7 +8,6 @@ import {
   Directory,
   DirectoryService,
 } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
-import { DirectoryService as LegacyDirectoryService } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/image";
 import {
   directoryToTreeViewBaseItems,
   getDefaultExpandedItems,
@@ -59,7 +58,7 @@ const DirectoryEditPage: FC = () => {
         slotProps={{
           item: {
             addNewChild: async (parentID: string) => {
-              await LegacyDirectoryService.CreateDirectory(
+              await DirectoryService.CreateDirectory(
                 newDirectoryName,
                 parseInt(parentID, 10)
               );
@@ -82,7 +81,7 @@ const DirectoryEditPage: FC = () => {
             directoryID,
             newLabel,
           });
-          await LegacyDirectoryService.UpdateName(directoryID, newLabel);
+          await DirectoryService.UpdateName(directoryID, newLabel);
           await refresh();
           // The label doesn't add a child tag correctly
         }}

--- a/internal/frontend/directory.go
+++ b/internal/frontend/directory.go
@@ -1,9 +1,17 @@
 package frontend
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
 
+	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
+	"github.com/michael-freling/anime-image-viewer/internal/xerrors"
 )
 
 type Directory struct {
@@ -21,9 +29,12 @@ func newDirectoryConverter() directoryConverter {
 }
 
 func (converter directoryConverter) convertDirectory(directory image.Directory) Directory {
-	children := make([]Directory, 0, len(directory.Children))
-	for _, child := range directory.Children {
-		children = append(children, converter.convertDirectory(*child))
+	var children []Directory
+	if len(directory.Children) > 0 {
+		children = make([]Directory, 0, len(directory.Children))
+		for _, child := range directory.Children {
+			children = append(children, converter.convertDirectory(*child))
+		}
 	}
 
 	return Directory{
@@ -35,20 +46,149 @@ func (converter directoryConverter) convertDirectory(directory image.Directory) 
 }
 
 type DirectoryService struct {
-	directoryReader *image.DirectoryReader
+	dbClient *db.Client
+
+	reader *image.DirectoryReader
 }
 
-func NewDirectoryService(directoryReader *image.DirectoryReader) *DirectoryService {
+func NewDirectoryService(
+	dbClient *db.Client,
+	directoryReader *image.DirectoryReader,
+) *DirectoryService {
 	return &DirectoryService{
-		directoryReader: directoryReader,
+		dbClient: dbClient,
+		reader:   directoryReader,
 	}
 }
 
 func (service DirectoryService) ReadDirectoryTree() (Directory, error) {
-	directory, err := service.directoryReader.ReadDirectoryTree()
+	directory, err := service.reader.ReadDirectoryTree()
 	if err != nil {
 		return Directory{}, fmt.Errorf("service.directoryReader.ReadDirectoryTree: %w", err)
 	}
 
+	return newDirectoryConverter().convertDirectory(directory), nil
+}
+
+func (service DirectoryService) CreateDirectory(ctx context.Context, name string, parentID uint) (Directory, error) {
+	rootDirectory := service.reader.ReadInitialDirectory()
+	if parentID != 0 {
+		currentDirectory, err := service.reader.ReadDirectory(parentID)
+		if err != nil {
+			return Directory{}, fmt.Errorf("service.readDirectory: %w", err)
+		}
+		if currentDirectory.ID == 0 {
+			return Directory{}, fmt.Errorf("%w: parent id %d", image.ErrDirectoryNotFound, parentID)
+		}
+		rootDirectory = currentDirectory.Path
+	}
+
+	directoryPath := filepath.Join(rootDirectory, name)
+	if _, err := os.Stat(directoryPath); err == nil {
+		return Directory{}, fmt.Errorf("%w: %s", image.ErrDirectoryAlreadyExists, name)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return Directory{}, fmt.Errorf("os.Stat: %w", err)
+	}
+
+	var directory db.File
+	err := db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
+		ormClient := service.dbClient.File()
+		record, err := ormClient.FindByValue(ctx, &db.File{
+			Name:     name,
+			ParentID: parentID,
+		})
+		if err != nil && err != db.ErrRecordNotFound {
+			return fmt.Errorf("ormClient.FindByValue: %w", err)
+		}
+		if record.ID != 0 && record.ParentID == parentID {
+			return fmt.Errorf("%w: %s", image.ErrDirectoryAlreadyExists, record.Name)
+		}
+
+		directory = db.File{
+			Name:     name,
+			ParentID: parentID,
+			Type:     db.FileTypeDirectory,
+		}
+		if err := ormClient.Create(ctx, &directory); err != nil {
+			return fmt.Errorf("ormClient.Create: %w", err)
+		}
+
+		// trying to create a directory
+		if err := os.Mkdir(directoryPath, 0755); err != nil {
+			return fmt.Errorf("os.Mkdir: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Directory{}, fmt.Errorf("db.NewTransaction: %w", err)
+	}
+
+	return Directory{
+		ID:   directory.ID,
+		Name: directory.Name,
+		Path: directoryPath,
+	}, nil
+}
+
+func (service DirectoryService) UpdateName(ctx context.Context, id uint, name string) (Directory, error) {
+	directory, err := service.reader.ReadDirectory(id)
+	if err != nil {
+		return Directory{}, fmt.Errorf("service.readDirectory: %w %d", err, id)
+	}
+	if directory.ID == 0 {
+		return Directory{}, fmt.Errorf("%w for id: %d", image.ErrDirectoryNotFound, id)
+	}
+	if directory.Name == name {
+		return Directory{}, fmt.Errorf("%w: directory name hasn't been changed: %s", xerrors.ErrInvalidArgument, name)
+	}
+	if _, err := os.Stat(directory.Path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return Directory{}, fmt.Errorf("%w in %s", image.ErrDirectoryNotFound, directory.Path)
+		}
+		return Directory{}, fmt.Errorf("os.Stat: %w", err)
+	}
+
+	_, err = db.FindByValue(service.dbClient, db.File{
+		Name:     name,
+		ParentID: directory.ParentID,
+	})
+	if err == nil && directory.ID != 0 {
+		return Directory{}, fmt.Errorf("%w for %s under parent directory id %d", image.ErrDirectoryAlreadyExists, name, directory.ParentID)
+	} else if !errors.Is(err, db.ErrRecordNotFound) {
+		return Directory{}, fmt.Errorf("db.FindValue: (%w)", err)
+	}
+
+	newDirectoryPath := path.Join(filepath.Dir(directory.Path), name)
+	if _, err := os.Stat(newDirectoryPath); err == nil {
+		return Directory{}, fmt.Errorf("%w for a path: %s", image.ErrDirectoryAlreadyExists, newDirectoryPath)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return Directory{}, fmt.Errorf("os.Stat: %w", err)
+	}
+
+	err = db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
+		ormClient := service.dbClient.File()
+		record, err := ormClient.FindByValue(ctx, &db.File{
+			ID: id,
+		})
+		if err != nil {
+			return fmt.Errorf("ormClient.FindByValue: %w", err)
+		}
+
+		record.Name = name
+		if err := ormClient.Update(ctx, &record); err != nil {
+			return fmt.Errorf("ormClient.Save: %w", err)
+		}
+
+		// trying to create a directory
+		if err := os.Rename(directory.Path, newDirectoryPath); err != nil {
+			return fmt.Errorf("os.Rename: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return Directory{}, fmt.Errorf("db.NewTransaction: %w", err)
+	}
+
+	directory.UpdateName(name)
 	return newDirectoryConverter().convertDirectory(directory), nil
 }

--- a/internal/frontend/directory.go
+++ b/internal/frontend/directory.go
@@ -1,10 +1,54 @@
 package frontend
 
-type Directory struct {
-	ID   uint   `json:"id"`
-	Name string `json:"name"`
-	Path string `json:"path"`
+import (
+	"fmt"
 
-	// legacy fields: May not necessary
-	ParentID uint `json:"parentId"`
+	"github.com/michael-freling/anime-image-viewer/internal/image"
+)
+
+type Directory struct {
+	ID       uint        `json:"id"`
+	Name     string      `json:"name"`
+	Path     string      `json:"path"`
+	Children []Directory `json:"children"`
+}
+
+type directoryConverter struct {
+}
+
+func newDirectoryConverter() directoryConverter {
+	return directoryConverter{}
+}
+
+func (converter directoryConverter) convertDirectory(directory image.Directory) Directory {
+	children := make([]Directory, 0, len(directory.Children))
+	for _, child := range directory.Children {
+		children = append(children, converter.convertDirectory(*child))
+	}
+
+	return Directory{
+		ID:       directory.ID,
+		Name:     directory.Name,
+		Path:     directory.Path,
+		Children: children,
+	}
+}
+
+type DirectoryService struct {
+	directoryReader *image.DirectoryReader
+}
+
+func NewDirectoryService(directoryReader *image.DirectoryReader) *DirectoryService {
+	return &DirectoryService{
+		directoryReader: directoryReader,
+	}
+}
+
+func (service DirectoryService) ReadDirectoryTree() (Directory, error) {
+	directory, err := service.directoryReader.ReadDirectoryTree()
+	if err != nil {
+		return Directory{}, fmt.Errorf("service.directoryReader.ReadDirectoryTree: %w", err)
+	}
+
+	return newDirectoryConverter().convertDirectory(directory), nil
 }

--- a/internal/frontend/main_test.go
+++ b/internal/frontend/main_test.go
@@ -53,6 +53,13 @@ func newTester(t *testing.T, opts ...newTesterOption) tester {
 	}
 }
 
+func (tester tester) getDirectoryService() *DirectoryService {
+	return NewDirectoryService(
+		tester.dbClient.Client,
+		tester.getDirectoryReader(),
+	)
+}
+
 func (tester tester) getSearchService() *SearchService {
 	return NewSearchService(
 		search.NewSearchRunner(

--- a/internal/image/directories.go
+++ b/internal/image/directories.go
@@ -2,11 +2,7 @@ package image
 
 import (
 	"errors"
-	"log/slog"
 	"path/filepath"
-
-	"github.com/michael-freling/anime-image-viewer/internal/config"
-	"github.com/michael-freling/anime-image-viewer/internal/db"
 )
 
 var (
@@ -121,34 +117,4 @@ func (parent Directory) GetDescendants() []Directory {
 		result = append(result, child.GetDescendants()...)
 	}
 	return result
-}
-
-type DirectoryService struct {
-	logger   *slog.Logger
-	config   config.Config
-	dbClient *db.Client
-
-	reader           *DirectoryReader
-	imageFileService *ImageFileService
-}
-
-func NewDirectoryService(
-	logger *slog.Logger,
-	conf config.Config,
-	dbClient *db.Client,
-	imageFileService *ImageFileService,
-	directoryReader *DirectoryReader,
-) *DirectoryService {
-	service := &DirectoryService{
-		logger:           logger,
-		config:           conf,
-		dbClient:         dbClient,
-		imageFileService: imageFileService,
-		reader:           directoryReader,
-	}
-	return service
-}
-
-func (service DirectoryService) ReadImageFiles(parentDirectoryID uint) ([]ImageFile, error) {
-	return service.reader.ReadImageFiles(parentDirectoryID)
 }

--- a/internal/image/directories.go
+++ b/internal/image/directories.go
@@ -155,20 +155,12 @@ func NewDirectoryService(
 	return service
 }
 
-func (service DirectoryService) ReadInitialDirectory() string {
-	return service.config.ImageRootDirectory
-}
-
 func (service DirectoryService) ReadImageFiles(parentDirectoryID uint) ([]ImageFile, error) {
 	return service.reader.ReadImageFiles(parentDirectoryID)
 }
 
-func (service DirectoryService) ReadChildDirectoriesRecursively(directoryID uint) ([]Directory, error) {
-	return service.reader.ReadChildDirectoriesRecursively(directoryID)
-}
-
 func (service DirectoryService) CreateDirectory(ctx context.Context, name string, parentID uint) (Directory, error) {
-	rootDirectory := service.ReadInitialDirectory()
+	rootDirectory := service.reader.readInitialDirectory()
 	if parentID != 0 {
 		currentDirectory, err := service.reader.ReadDirectory(parentID)
 		if err != nil {
@@ -226,10 +218,6 @@ func (service DirectoryService) CreateDirectory(ctx context.Context, name string
 		Path:     directoryPath,
 		ParentID: directory.ParentID,
 	}, nil
-}
-
-func (service DirectoryService) CreateTopDirectory(ctx context.Context, name string) (Directory, error) {
-	return service.CreateDirectory(ctx, name, db.RootDirectoryID)
 }
 
 func (service DirectoryService) UpdateName(ctx context.Context, id uint, name string) (Directory, error) {

--- a/internal/image/directory_reader.go
+++ b/internal/image/directory_reader.go
@@ -25,7 +25,7 @@ func NewDirectoryReader(config config.Config, dbClient *db.Client) *DirectoryRea
 	}
 }
 
-func (service DirectoryReader) readInitialDirectory() string {
+func (service DirectoryReader) ReadInitialDirectory() string {
 	return service.config.ImageRootDirectory
 }
 
@@ -127,8 +127,8 @@ func (service DirectoryReader) ReadDirectoryTree() (Directory, error) {
 	directoryMap := make(map[uint]*Directory)
 	directoryMap[db.RootDirectoryID] = &Directory{
 		ID:           db.RootDirectoryID,
-		Name:         service.readInitialDirectory(),
-		Path:         service.readInitialDirectory(),
+		Name:         service.ReadInitialDirectory(),
+		Path:         service.ReadInitialDirectory(),
 		RelativePath: "",
 		ParentID:     0,
 	}
@@ -155,7 +155,7 @@ func (service DirectoryReader) ReadDirectoryTree() (Directory, error) {
 		childDirectoryMap,
 		childImageFileMap,
 		db.RootDirectoryID,
-		service.readInitialDirectory(),
+		service.ReadInitialDirectory(),
 		"",
 	)
 	return *root, nil

--- a/internal/image/directory_reader.go
+++ b/internal/image/directory_reader.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
-	"github.com/michael-freling/anime-image-viewer/internal/xslices"
 )
 
 type DirectoryReader struct {
@@ -76,16 +75,6 @@ func (service DirectoryReader) ReadImageFilesRecursively(directory Directory) ([
 		imageFiles = append(imageFiles, childImageFiles...)
 	}
 	return imageFiles, nil
-}
-
-func (service DirectoryReader) ReadChildDirectoriesRecursively(directoryID uint) ([]Directory, error) {
-	directory, err := service.ReadDirectory(directoryID)
-	if err != nil {
-		return nil, fmt.Errorf("service.ReadDirectory: %w", err)
-	}
-	return xslices.Map(directory.dropChildImageFiles().Children, func(dir *Directory) Directory {
-		return *dir
-	}), nil
 }
 
 // ReadAncestors reads the ancestors of the given file IDs, including the file itself.

--- a/internal/image/main_test.go
+++ b/internal/image/main_test.go
@@ -55,32 +55,8 @@ func newTester(t *testing.T, opts ...newTesterOption) Tester {
 	}
 }
 
-func (tester Tester) getFileService() *ImageFileService {
-	return NewFileService(
-		tester.logger,
-		tester.dbClient.Client,
-		tester.getDirectoryReader(),
-		tester.getImageFileConverter(),
-	)
-}
-
-func (tester Tester) getDirectoryService() *DirectoryService {
-	fileService := tester.getFileService()
-	return NewDirectoryService(
-		tester.logger,
-		tester.config,
-		tester.dbClient.Client,
-		fileService,
-		tester.getDirectoryReader(),
-	)
-}
-
 func (tester Tester) getDirectoryReader() *DirectoryReader {
 	return NewDirectoryReader(tester.config, tester.dbClient.Client)
-}
-
-func (tester Tester) getImageFileConverter() *ImageFileConverter {
-	return NewImageFileConverter(tester.config)
 }
 
 func (tester Tester) newFileCreator() *FileCreator {

--- a/main.go
+++ b/main.go
@@ -118,14 +118,8 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 		directoryReader,
 		imageFileConverter,
 	)
-	legacyDirectoryService := image.NewDirectoryService(
-		logger,
-		conf,
-		dbClient,
-		legacyImageService,
-		directoryReader,
-	)
 	directoryService := frontend.NewDirectoryService(
+		dbClient,
 		directoryReader,
 	)
 	tagReader := tag.NewReader(dbClient, directoryReader)
@@ -167,7 +161,6 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 			application.NewService(imageService),
 			application.NewService(legacyImageService),
 			application.NewService(directoryService),
-			application.NewService(legacyDirectoryService),
 			application.NewService(tagService),
 			application.NewService(legacyTagFrontendService),
 			application.NewService(configService),

--- a/main.go
+++ b/main.go
@@ -118,11 +118,14 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 		directoryReader,
 		imageFileConverter,
 	)
-	directoryService := image.NewDirectoryService(
+	legacyDirectoryService := image.NewDirectoryService(
 		logger,
 		conf,
 		dbClient,
 		legacyImageService,
+		directoryReader,
+	)
+	directoryService := frontend.NewDirectoryService(
 		directoryReader,
 	)
 	tagReader := tag.NewReader(dbClient, directoryReader)
@@ -164,6 +167,7 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 			application.NewService(imageService),
 			application.NewService(legacyImageService),
 			application.NewService(directoryService),
+			application.NewService(legacyDirectoryService),
 			application.NewService(tagService),
 			application.NewService(legacyTagFrontendService),
 			application.NewService(configService),


### PR DESCRIPTION
- It is unclear where images are stored. Show a root directory on the UI for users to see where they're stored.
- Update UI not to allow changing a name of the root directory nor importing images in the directory. 