### PR TITLE
feat: flatten tags and add tag edit page improvements

### DIFF
--- a/frontend/src/components/DirectoryExplorer.tsx
+++ b/frontend/src/components/DirectoryExplorer.tsx
@@ -26,7 +26,7 @@ export function directoryToTreeViewBaseItems(
   return {
     id: String(directory.id),
     label: directory.name,
-    tags: tagsMap ? tagsMap.map((tagId) => allTags[tagId].fullName) : [],
+    tags: tagsMap ? tagsMap.map((tagId) => allTags[tagId].name) : [],
 
     children: directory.children.map((child) => {
       return directoryToTreeViewBaseItems(child, allTags, directoryTagMap);

--- a/frontend/src/components/ExplorerTreeItem.tsx
+++ b/frontend/src/components/ExplorerTreeItem.tsx
@@ -1,5 +1,5 @@
 // TreeView hasn't been supported by a Joy UI yet: https://github.com/mui/mui-x/issues/14687
-import { Add, EditOutlined, Upload } from "@mui/icons-material";
+import { Add, CallMerge, DeleteOutlined, EditOutlined, Upload } from "@mui/icons-material";
 import { Checkbox, Chip, IconButton, Stack } from "@mui/joy";
 import {
   TreeItem2,
@@ -15,6 +15,8 @@ export interface ExplorerTreeItemLabelProps
   editable: boolean;
   tags: string[];
   addNewChild: () => Promise<void>;
+  deleteItem?: () => Promise<void>;
+  mergeItem?: () => void;
   toggleItemEditing: (() => void) | null;
   importImages: () => Promise<void> | null;
 }
@@ -26,6 +28,8 @@ export function ExplorerTreeItemLabel({
   tags,
   toggleItemEditing, // only for editable
   addNewChild, // only for editable
+  deleteItem, // only for editable
+  mergeItem, // only for editable
   importImages, // only for editable
   ...other
 }: ExplorerTreeItemLabelProps) {
@@ -84,6 +88,30 @@ export function ExplorerTreeItemLabel({
           >
             <Add />
           </IconButton>
+          {mergeItem == null ? null : (
+            <IconButton
+              variant="outlined"
+              color="neutral"
+              onClick={(event: SyntheticEvent) => {
+                event.stopPropagation();
+                mergeItem();
+              }}
+            >
+              <CallMerge />
+            </IconButton>
+          )}
+          {deleteItem == null ? null : (
+            <IconButton
+              variant="outlined"
+              color="danger"
+              onClick={(event: SyntheticEvent) => {
+                event.stopPropagation();
+                deleteItem();
+              }}
+            >
+              <DeleteOutlined />
+            </IconButton>
+          )}
           {toggleItemEditing == null ? null : (
             <IconButton
               variant="outlined"
@@ -212,6 +240,8 @@ export const ExplorerTreeItemWithCheckbox = React.forwardRef(
 
 export interface ExplorerTreeItemProps extends TreeItem2Props {
   addNewChild: (parentID: string) => Promise<void>;
+  deleteItem?: (itemId: string) => Promise<void>;
+  mergeItem?: (itemId: string) => void;
   importImages?: (parentID: string) => Promise<void>;
 }
 export const ExplorerTreeItem = React.forwardRef(function CustomTreeItem(
@@ -229,7 +259,7 @@ export const ExplorerTreeItem = React.forwardRef(function CustomTreeItem(
       event.defaultMuiPrevented = true;
     };
 
-  const { addNewChild, importImages } = props as ExplorerTreeItemProps;
+  const { addNewChild, deleteItem, mergeItem, importImages } = props as ExplorerTreeItemProps;
 
   const onImportImages =
     importImages == null || itemId == "0"
@@ -258,6 +288,16 @@ export const ExplorerTreeItem = React.forwardRef(function CustomTreeItem(
           addNewChild: () => {
             addNewChild(itemId);
           },
+          deleteItem: deleteItem
+            ? () => {
+                deleteItem(itemId);
+              }
+            : undefined,
+          mergeItem: mergeItem
+            ? () => {
+                mergeItem(itemId);
+              }
+            : undefined,
           toggleItemEditing: onToggleItemEditing,
           importImages: onImportImages,
         } as ExplorerTreeItemLabelProps,

--- a/frontend/src/components/SelectTagExplorer.tsx
+++ b/frontend/src/components/SelectTagExplorer.tsx
@@ -23,9 +23,9 @@ const tagsToTreeViewBaseItems = (
   indeterminate: boolean;
   checked: boolean;
 }>[] => {
-  return tags.map((child) => {
-    const isAdded = addedTagIds[child.id];
-    const isDeleted = deletedTagIds[child.id];
+  return tags.map((tag) => {
+    const isAdded = addedTagIds[tag.id];
+    const isDeleted = deletedTagIds[tag.id];
 
     let count: number | undefined = undefined;
     let disabled = false;
@@ -33,28 +33,19 @@ const tagsToTreeViewBaseItems = (
 
     if (tagStats != undefined) {
       count = 0;
-      const tagStat: TagStat = tagStats[child.id];
+      const tagStat: TagStat = tagStats[tag.id];
       if (tagStat != null) {
         if (tagStat.fileCount > 0) {
           count = tagStat.fileCount;
           indeterminate =
             isAdded == undefined && isDeleted == undefined && count < fileCount;
         }
-
-        disabled = !tagStat.isAddedBySelectedFiles && tagStat.isAddedByAncestor;
       }
     }
 
     return {
-      id: String(child.id),
-      label: child.name,
-      children: tagsToTreeViewBaseItems(
-        (child.children ?? []).filter((child) => child != null),
-        fileCount,
-        addedTagIds,
-        deletedTagIds,
-        tagStats
-      ),
+      id: String(tag.id),
+      label: tag.name,
       count,
       indeterminate,
       checked: isAdded || count == fileCount,
@@ -192,7 +183,7 @@ export const SelectTagExplorer: FC<SelectTagExplorerProps> = ({
     selectedTagIds = [props.selectedTagId];
   } else if (tagStats != undefined) {
     for (const [tagId, stats] of Object.entries(tagStats)) {
-      if (stats.isAddedBySelectedFiles || stats.isAddedByAncestor) {
+      if (stats.isAddedBySelectedFiles) {
         selectedTagIds.push(parseInt(tagId));
       }
     }

--- a/frontend/src/components/SelectTagExplorer.tsx
+++ b/frontend/src/components/SelectTagExplorer.tsx
@@ -28,7 +28,7 @@ const tagsToTreeViewBaseItems = (
     const isDeleted = deletedTagIds[tag.id];
 
     let count: number | undefined = undefined;
-    let disabled = false;
+    const disabled = false;
     let indeterminate = false;
 
     if (tagStats != undefined) {
@@ -191,7 +191,7 @@ export const SelectTagExplorer: FC<SelectTagExplorerProps> = ({
   const defaultSelectedItems = selectedTagIds.map((id) => String(id));
   // selected items should be visible as default.
   // So, we need to expand all parent items of selected items.
-  const defaultExpandedItems = getDefaultExpandedItems(selectedTagIds, tagMap);
+  const defaultExpandedItems = getDefaultExpandedItems();
 
   return (
     <RichTreeView

--- a/frontend/src/components/TagExplorer.tsx
+++ b/frontend/src/components/TagExplorer.tsx
@@ -16,14 +16,10 @@ export const tagsToTreeViewBaseItems = (
   id: string;
   label: string;
 }>[] => {
-  return tags.map((child) => {
+  return tags.map((tag) => {
     return {
-      id: String(child.id),
-      label: child.name,
-      children: tagsToTreeViewBaseItems(
-        (child.children ?? []).filter((child) => child != null),
-        fileCount
-      ),
+      id: String(tag.id),
+      label: tag.name,
     };
   });
 };
@@ -32,52 +28,15 @@ export const getTagMap = (tags: Tag[]): { [id: number]: Tag } => {
   const map: { [id: number]: Tag } = {};
   tags.forEach((tag) => {
     map[tag.id] = tag;
-    Object.assign(
-      map,
-      getTagMap((tag.children || []).filter((child) => child != null))
-    );
   });
   return map;
 };
-
-// function getAncestorIds(id: number, tagMap: { [id: number]: Tag }): number[] {
-//   const result: number[] = [];
-//   let selectedTag = tagMap[id];
-//   while (selectedTag != null) {
-//     result.push(selectedTag.id);
-//     if (selectedTag.parentId == null) {
-//       break;
-//     }
-//     selectedTag = tagMap[selectedTag.parentId];
-//   }
-//   return result;
-// }
 
 export function getDefaultExpandedItems(
   _: number[],
   tagMap: { [id: number]: Tag }
 ) {
-  const defaultExpandedItems: string[] = [];
-  for (const tagId of Object.keys(tagMap)) {
-    defaultExpandedItems.push(tagId);
-  }
-  return defaultExpandedItems;
-
-  // expand only selected and indeterminate items
-  //   let defaultExpandedItems: string[] = [];
-  //   for (let selectedItemId of selectedTagIds) {
-  //     const ancestorIds = getAncestorIds(selectedItemId, tagMap);
-  //     defaultExpandedItems.push(...ancestorIds.map((id) => String(id)));
-  //   }
-  //   // expand tags with indeterminate states
-  //   if (tagStats != undefined) {
-  //     for (let [tagId, count] of Object.entries(tagStats.TagCounts)) {
-  //       if (0 < count && count < fileIds.length) {
-  //         const ancestorIds = getAncestorIds(parseInt(tagId), tagMap);
-  //         defaultExpandedItems.push(...ancestorIds.map((id) => String(id)));
-  //       }
-  //     }
-  //   }
+  return [];
 }
 
 export interface TagExplorerProps {

--- a/frontend/src/components/TagExplorer.tsx
+++ b/frontend/src/components/TagExplorer.tsx
@@ -10,8 +10,7 @@ import {
 import { ExplorerTreeItem } from "./ExplorerTreeItem";
 
 export const tagsToTreeViewBaseItems = (
-  tags: Tag[],
-  fileCount: number
+  tags: Tag[]
 ): TreeViewBaseItem<{
   id: string;
   label: string;
@@ -32,10 +31,7 @@ export const getTagMap = (tags: Tag[]): { [id: number]: Tag } => {
   return map;
 };
 
-export function getDefaultExpandedItems(
-  _: number[],
-  tagMap: { [id: number]: Tag }
-) {
+export function getDefaultExpandedItems() {
   return [];
 }
 
@@ -45,7 +41,6 @@ export interface TagExplorerProps {
 const TagExplorer: FC<TagExplorerProps> = (props) => {
   const navigate = useNavigate();
   const [children, setChildren] = useState<Tag[]>([]);
-  const [tagMap, setTagMap] = useState<{ [id: number]: Tag }>({});
 
   useEffect(() => {
     if (children.length > 0) {
@@ -58,14 +53,13 @@ const TagExplorer: FC<TagExplorerProps> = (props) => {
   async function refresh() {
     const tags = await TagFrontendService.GetAll();
     setChildren(tags);
-    setTagMap(getTagMap(tags));
   }
 
   if (children.length === 0) {
     return <Typography>Loading...</Typography>;
   }
 
-  const treeItems = tagsToTreeViewBaseItems(children, 0);
+  const treeItems = tagsToTreeViewBaseItems(children);
 
   const { title } = props;
 
@@ -84,7 +78,7 @@ const TagExplorer: FC<TagExplorerProps> = (props) => {
 
       <RichTreeView
         expansionTrigger="content"
-        defaultExpandedItems={getDefaultExpandedItems([], tagMap)}
+        defaultExpandedItems={getDefaultExpandedItems()}
         slots={{
           // todo: RichTreeView doesn't allow to pass a type other than TreeItem2Props
           item: ExplorerTreeItem as any,

--- a/frontend/src/pages/tags/ImageTagSuggestionPage.tsx
+++ b/frontend/src/pages/tags/ImageTagSuggestionPage.tsx
@@ -95,9 +95,6 @@ const ImageTagSuggestionPage: React.FC = () => {
           if (suggestion.hasTag) {
             continue;
           }
-          if (suggestion.hasDescendantTag) {
-            continue;
-          }
           if (suggestion.score * 100 < selectedScore) {
             continue;
           }
@@ -210,7 +207,7 @@ const ImageTagSuggestionPage: React.FC = () => {
 
                 return (
                   <Chip key={tagId} color="primary">
-                    {tags[tagId].full_name}
+                    {tags[tagId].name}
                   </Chip>
                 );
               })}
@@ -221,7 +218,7 @@ const ImageTagSuggestionPage: React.FC = () => {
                 if (!(tagId in tags)) {
                   return null;
                 }
-                if (suggestion.hasTag || suggestion.hasDescendantTag) {
+                if (suggestion.hasTag) {
                   return null;
                 }
                 const score = suggestion.score * 100;
@@ -231,7 +228,7 @@ const ImageTagSuggestionPage: React.FC = () => {
                 const color = disabled ? "neutral" : "success";
                 return (
                   <Chip key={tagId} color={color} disabled={disabled}>
-                    {tags[tagId].full_name} ({score.toFixed(0)}%)
+                    {tags[tagId].name} ({score.toFixed(0)}%)
                   </Chip>
                 );
               })}

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -1,7 +1,26 @@
-import { IconButton, Typography } from "@mui/joy";
-import { RichTreeView } from "@mui/x-tree-view";
-import { FC, useEffect, useState } from "react";
 import {
+  Box,
+  Divider,
+  IconButton,
+  Input,
+  List,
+  ListItemButton,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  ModalOverflow,
+  Sheet,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { RichTreeView, TreeViewBaseItem } from "@mui/x-tree-view";
+import React, { FC, useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
+import {
+  Directory,
+  DirectoryService,
+  Image,
+  SearchService,
   Tag,
   TagService,
 } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
@@ -10,16 +29,35 @@ import {
   ExplorerTreeItem,
   ExplorerTreeItemProps,
 } from "../../components/ExplorerTreeItem";
+import { ImageList } from "../../components/Images/ImageList";
+import ImageWindow from "../../components/Images/ImageWindow";
+import { ViewImageType } from "../../components/Images/ViewImage";
 import {
   tagsToTreeViewBaseItems,
   getDefaultExpandedItems,
 } from "../../components/TagExplorer";
 import Layout from "../../Layout";
-import { Add } from "@mui/icons-material";
+import { Add, Search } from "@mui/icons-material";
+import FolderIcon from "@mui/icons-material/Folder";
+import FolderOpenIcon from "@mui/icons-material/FolderOpen";
 
 export const TagsListPage: FC = () => {
   const [tags, setTags] = useState<Tag[]>([]);
+  const [tagSearch, setTagSearch] = useState("");
   const [isTagLoaded, setTagLoaded] = useState(false);
+  const [mergeSourceId, setMergeSourceId] = useState<number | null>(null);
+  const [selectedTagId, setSelectedTagId] = useState<number | null>(null);
+  const [previewImages, setPreviewImages] = useState<Image[]>([]);
+  const [rootDirectory, setRootDirectory] = useState<Directory | null>(null);
+  const [tagToDirectoryIds, setTagToDirectoryIds] = useState<
+    Map<number, number[]>
+  >(new Map());
+  const [selectedViewImageId, setSelectedViewImageId] = useState<number | null>(
+    null
+  );
+
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
 
   useEffect(() => {
     if (tags.length > 0) {
@@ -29,17 +67,154 @@ export const TagsListPage: FC = () => {
     refresh();
   }, []);
 
+  useEffect(() => {
+    (async () => {
+      const response = await DirectoryService.ReadDirectoryTree();
+      setRootDirectory(response.rootDirectory);
+
+      const inverted = new Map<number, number[]>();
+      const tagMap = response.tagMap ?? {};
+      for (const [fileIdStr, tagIds] of Object.entries(tagMap)) {
+        const fileId = Number(fileIdStr);
+        for (const tagId of tagIds as number[]) {
+          const existing = inverted.get(tagId) ?? [];
+          existing.push(fileId);
+          inverted.set(tagId, existing);
+        }
+      }
+      setTagToDirectoryIds(inverted);
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (selectedTagId == null) {
+      setPreviewImages([]);
+      return;
+    }
+    (async () => {
+      const response = await SearchService.SearchImages({
+        tagId: selectedTagId,
+      });
+      setPreviewImages((response.images ?? []).slice(0, 6));
+    })();
+  }, [selectedTagId]);
+
+  const previewViewImages = useMemo<ViewImageType[]>(
+    () => previewImages.map((image) => ({ ...image, selected: false })),
+    [previewImages]
+  );
+
+  const taggedDirIds = useMemo<Set<number>>(() => {
+    if (selectedTagId == null) return new Set();
+    return new Set(tagToDirectoryIds.get(selectedTagId) ?? []);
+  }, [selectedTagId, tagToDirectoryIds]);
+
+  const selectedTagName = useMemo(() => {
+    if (selectedTagId == null) return "";
+    return tags.find((t) => t.id === selectedTagId)?.name ?? "";
+  }, [selectedTagId, tags]);
+
+  const previewDirectoryTreeItems = useMemo<
+    TreeViewBaseItem<{ id: string; label: string; tags: string[] }>[]
+  >(() => {
+    if (rootDirectory == null || taggedDirIds.size === 0) return [];
+    type PreviewTreeItem = TreeViewBaseItem<{
+      id: string;
+      label: string;
+      tags: string[];
+    }>;
+    const buildFilteredTree = (dir: Directory): PreviewTreeItem | null => {
+      const children: PreviewTreeItem[] = [];
+      for (const child of dir.children ?? []) {
+        const built = buildFilteredTree(child);
+        if (built) children.push(built);
+      }
+      const isTagged = taggedDirIds.has(dir.id);
+      if (!isTagged && children.length === 0) return null;
+      return {
+        id: String(dir.id),
+        label: dir.name,
+        tags: isTagged && selectedTagName ? [selectedTagName] : [],
+        children,
+      };
+    };
+    const items: PreviewTreeItem[] = [];
+    for (const child of rootDirectory.children ?? []) {
+      const built = buildFilteredTree(child);
+      if (built) items.push(built);
+    }
+    return items;
+  }, [rootDirectory, taggedDirIds, selectedTagName]);
+
+  const previewExpandedItems = useMemo<string[]>(() => {
+    const ids: string[] = [];
+    const walk = (
+      items: TreeViewBaseItem<{ id: string; label: string; tags: string[] }>[]
+    ) => {
+      for (const item of items) {
+        ids.push(item.id);
+        if (item.children && item.children.length > 0) {
+          walk(
+            item.children as TreeViewBaseItem<{
+              id: string;
+              label: string;
+              tags: string[];
+            }>[]
+          );
+        }
+      }
+    };
+    walk(previewDirectoryTreeItems);
+    return ids;
+  }, [previewDirectoryTreeItems]);
+
   async function refresh() {
     const tags = await TagService.GetAll();
     setTags(tags);
     setTagLoaded(true);
   }
 
-  const treeItems = tagsToTreeViewBaseItems(tags);
+  const filteredSortedTags = useMemo(() => {
+    const q = tagSearch.trim().toLowerCase();
+    const filtered = q
+      ? tags.filter((t) => t.name.toLowerCase().includes(q))
+      : tags.slice();
+    filtered.sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+    );
+    return filtered;
+  }, [tags, tagSearch]);
+
+  const treeItems = useMemo(
+    () => tagsToTreeViewBaseItems(filteredSortedTags),
+    [filteredSortedTags]
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const addNewChild = async (_parentID: string) => {
     await LegacyTagFrontendService.CreateTopTag("New Tag");
+    await refresh();
+  };
+
+  const deleteTag = async (tagId: string) => {
+    const id = parseInt(tagId, 10);
+    const count = await LegacyTagFrontendService.GetTagFileCount(id);
+    if (count > 0) {
+      const confirmed = window.confirm(
+        `This tag is used by ${count} image(s). Are you sure you want to delete it?`
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+    await LegacyTagFrontendService.DeleteTag(id);
+    await refresh();
+  };
+
+  const mergeTag = async (targetTagId: number) => {
+    if (mergeSourceId == null) return;
+    await LegacyTagFrontendService.MergeTags(mergeSourceId, targetTagId);
+    setMergeSourceId(null);
     await refresh();
   };
 
@@ -64,31 +239,209 @@ export const TagsListPage: FC = () => {
     >
       {!isTagLoaded && <Typography>Loading...</Typography>}
       {isTagLoaded && (
-        <RichTreeView
-          expansionTrigger="content"
-          defaultExpandedItems={getDefaultExpandedItems()}
-          slots={{
-            // todo: RichTreeView doesn't allow to pass a type other than TreeItem2Props
-            item: ExplorerTreeItem as any,
+        <Box
+          sx={{
+            display: "flex",
+            gap: 2,
+            height: "100%",
+            overflow: "hidden",
           }}
-          slotProps={{
-            item: {
-              addNewChild,
-            } as ExplorerTreeItemProps,
-          }}
-          isItemEditable={() => true}
-          experimentalFeatures={{ labelEditing: true }}
-          items={treeItems}
-          onItemLabelChange={async (itemId, newLabel) => {
-            await LegacyTagFrontendService.UpdateName(
-              parseInt(itemId, 10),
-              newLabel
-            );
-            // todo: Update only changed tag
-            await refresh();
-          }}
-        />
+        >
+          <Sheet
+            variant="outlined"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              p: 1,
+              borderRadius: "sm",
+            }}
+          >
+            <Stack spacing={1} sx={{ height: "100%" }}>
+              <Input
+                size="sm"
+                placeholder="Search tags"
+                startDecorator={<Search fontSize="small" />}
+                value={tagSearch}
+                onChange={(e) => setTagSearch(e.target.value)}
+              />
+              <Box sx={{ flex: 1, overflow: "auto" }}>
+                <RichTreeView
+                  expansionTrigger="content"
+                  defaultExpandedItems={getDefaultExpandedItems()}
+                  slots={{
+                    // todo: RichTreeView doesn't allow to pass a type other than TreeItem2Props
+                    item: ExplorerTreeItem as any,
+                  }}
+                  slotProps={{
+                    item: {
+                      addNewChild,
+                      deleteItem: deleteTag,
+                      mergeItem: (itemId: string) => {
+                        setMergeSourceId(parseInt(itemId, 10));
+                      },
+                    } as ExplorerTreeItemProps,
+                  }}
+                  isItemEditable={() => true}
+                  experimentalFeatures={{ labelEditing: true }}
+                  items={treeItems}
+                  onSelectedItemsChange={(
+                    _event: React.SyntheticEvent,
+                    itemId: string | null
+                  ) => {
+                    if (itemId == null || itemId === "0") {
+                      setSelectedTagId(null);
+                      return;
+                    }
+                    const parsed = parseInt(itemId, 10);
+                    setSelectedTagId(Number.isNaN(parsed) ? null : parsed);
+                  }}
+                  onItemLabelChange={async (itemId, newLabel) => {
+                    await LegacyTagFrontendService.UpdateName(
+                      parseInt(itemId, 10),
+                      newLabel
+                    );
+                    // todo: Update only changed tag
+                    await refresh();
+                  }}
+                />
+              </Box>
+            </Stack>
+          </Sheet>
+          <Box
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              py: 1,
+            }}
+          >
+            {selectedTagId == null ? (
+              <Typography level="body-md" sx={{ color: "text.secondary" }}>
+                Select a tag to preview its images and folders.
+              </Typography>
+            ) : (
+              <Stack spacing={2} sx={{ flex: 1, minHeight: 0 }}>
+                <Box sx={{ flexShrink: 0, maxHeight: "50%", overflowY: "auto", minHeight: 0 }}>
+                  <Typography level="title-md" sx={{ mb: 1 }}>
+                    Folders with this tag
+                  </Typography>
+                  {previewDirectoryTreeItems.length === 0 ? (
+                    <Typography
+                      level="body-sm"
+                      sx={{ color: "text.tertiary" }}
+                    >
+                      No folders.
+                    </Typography>
+                  ) : (
+                    <RichTreeView
+                      key={selectedTagId ?? "none"}
+                      defaultExpandedItems={previewExpandedItems}
+                      slots={{
+                        // todo: RichTreeView doesn't allow to pass a type other than TreeItem2Props
+                        item: ExplorerTreeItem as any,
+                        expandIcon: (props) => (
+                          <FolderIcon color="primary" {...props} />
+                        ),
+                        collapseIcon: (props) => (
+                          <FolderOpenIcon color="primary" {...props} />
+                        ),
+                        endIcon: (props) => (
+                          <FolderOpenIcon color="primary" {...props} />
+                        ),
+                      }}
+                      slotProps={{
+                        item: {
+                          addNewChild: async () => {},
+                        } as unknown as ExplorerTreeItemProps,
+                      }}
+                      items={previewDirectoryTreeItems}
+                      onSelectedItemsChange={(_event, itemId) => {
+                        if (!itemId) return;
+                        navigate({
+                          pathname: `/directories/${itemId}`,
+                          search: searchParams.toString(),
+                        });
+                      }}
+                    />
+                  )}
+                </Box>
+
+                <Divider />
+
+                <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
+                  <Typography level="title-md" sx={{ mb: 1 }}>
+                    Images with this tag
+                  </Typography>
+                  {previewViewImages.length === 0 ? (
+                    <Typography
+                      level="body-sm"
+                      sx={{ color: "text.tertiary" }}
+                    >
+                      No images.
+                    </Typography>
+                  ) : (
+                    <Box sx={{ flex: 1, minHeight: 0, width: "100%" }}>
+                      <ImageList
+                        mode="view"
+                        images={previewViewImages}
+                        onChange={() => {}}
+                        onView={(image) => setSelectedViewImageId(image.id)}
+                      />
+                    </Box>
+                  )}
+                </Box>
+              </Stack>
+            )}
+          </Box>
+        </Box>
       )}
+
+      {selectedViewImageId != null && (
+        <Modal open={true} onClose={() => setSelectedViewImageId(null)}>
+          <ModalOverflow>
+            <ModalDialog
+              aria-labelledby="tag-preview-image-window"
+              layout="fullscreen"
+              sx={{ p: 0, m: 0 }}
+            >
+              <ImageWindow
+                images={previewViewImages}
+                initialId={selectedViewImageId}
+              />
+            </ModalDialog>
+          </ModalOverflow>
+        </Modal>
+      )}
+
+      {/* Merge target selection modal */}
+      <Modal open={mergeSourceId != null} onClose={() => setMergeSourceId(null)}>
+        <ModalDialog>
+          <ModalClose />
+          <Typography level="title-md">
+            Merge &quot;{tags.find((t) => t.id === mergeSourceId)?.name}&quot; into:
+          </Typography>
+          <List
+            sx={{
+              maxHeight: 400,
+              overflow: "auto",
+            }}
+          >
+            {tags
+              .filter((t) => t.id !== mergeSourceId)
+              .map((tag) => (
+                <ListItemButton
+                  key={tag.id}
+                  onClick={() => mergeTag(tag.id)}
+                >
+                  {tag.name}
+                </ListItemButton>
+              ))}
+          </List>
+        </ModalDialog>
+      </Modal>
     </Layout.Main>
   );
 };

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -11,16 +11,14 @@ import {
   ExplorerTreeItemProps,
 } from "../../components/ExplorerTreeItem";
 import {
-  getTagMap,
   tagsToTreeViewBaseItems,
+  getDefaultExpandedItems,
 } from "../../components/TagExplorer";
 import Layout from "../../Layout";
 import { Add } from "@mui/icons-material";
-import { getDefaultExpandedItems } from "../../components/TagExplorer";
 
 export const TagsListPage: FC = () => {
   const [tags, setTags] = useState<Tag[]>([]);
-  const [tagMap, setTagMap] = useState<{ [id: number]: Tag }>({});
   const [isTagLoaded, setTagLoaded] = useState(false);
 
   useEffect(() => {
@@ -34,12 +32,12 @@ export const TagsListPage: FC = () => {
   async function refresh() {
     const tags = await TagService.GetAll();
     setTags(tags);
-    setTagMap(getTagMap(tags));
     setTagLoaded(true);
   }
 
-  const treeItems = tagsToTreeViewBaseItems(tags, 0);
+  const treeItems = tagsToTreeViewBaseItems(tags);
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const addNewChild = async (_parentID: string) => {
     await LegacyTagFrontendService.CreateTopTag("New Tag");
     await refresh();
@@ -68,7 +66,7 @@ export const TagsListPage: FC = () => {
       {isTagLoaded && (
         <RichTreeView
           expansionTrigger="content"
-          defaultExpandedItems={getDefaultExpandedItems([], tagMap)}
+          defaultExpandedItems={getDefaultExpandedItems()}
           slots={{
             // todo: RichTreeView doesn't allow to pass a type other than TreeItem2Props
             item: ExplorerTreeItem as any,

--- a/frontend/src/pages/tags/TagsListPage.tsx
+++ b/frontend/src/pages/tags/TagsListPage.tsx
@@ -40,12 +40,8 @@ export const TagsListPage: FC = () => {
 
   const treeItems = tagsToTreeViewBaseItems(tags, 0);
 
-  const addNewChild = async (parentID: string) => {
-    await LegacyTagFrontendService.Create({
-      Name: "New Tag",
-      ParentID: parseInt(parentID, 10),
-    });
-    // todo: Update only added tag
+  const addNewChild = async (_parentID: string) => {
+    await LegacyTagFrontendService.CreateTopTag("New Tag");
     await refresh();
   };
 

--- a/internal/config/reader_test.go
+++ b/internal/config/reader_test.go
@@ -300,6 +300,46 @@ func TestReadConfig_UnreadableFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "os.OpenFile")
 }
 
+func TestDefaultConfig(t *testing.T) {
+	conf, err := DefaultConfig()
+	require.NoError(t, err)
+
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	// Verify ImageRootDirectory contains the home directory
+	assert.Contains(t, conf.ImageRootDirectory, homeDir)
+	assert.Contains(t, conf.ImageRootDirectory, "anime-image-viewer")
+
+	// Verify ConfigDirectory
+	expectedConfigDir := filepath.Join(homeDir, ".config", "anime-image-viewer")
+	assert.Equal(t, expectedConfigDir, conf.ConfigDirectory)
+
+	// Verify LogDirectory contains temp dir
+	assert.Contains(t, conf.LogDirectory, "anime-image-viewer")
+	assert.Contains(t, conf.LogDirectory, "logs")
+
+	// Verify Backup defaults
+	assert.Equal(t, filepath.Join(expectedConfigDir, "backups"), conf.Backup.BackupDirectory)
+	assert.Equal(t, 7, conf.Backup.RetentionCount)
+	assert.Equal(t, 30, conf.Backup.IdleMinutes)
+	assert.True(t, conf.Backup.IdleBackupIncludeImages)
+
+	// Verify Environment is set
+	assert.NotEmpty(t, conf.Environment)
+}
+
+func TestDefaultImageRootDirectory(t *testing.T) {
+	homeDir := "/fake/home"
+	got := defaultImageRootDirectory(homeDir)
+	assert.Contains(t, got, homeDir)
+	assert.Contains(t, got, "anime-image-viewer")
+	// In development mode (the default for tests), it should contain the environment suffix
+	if runtimeEnv == EnvironmentDevelopment {
+		assert.Contains(t, got, string(EnvironmentDevelopment))
+	}
+}
+
 func TestReadConfig_BackupAllFieldsExplicit(t *testing.T) {
 	tomlContent := `
 image_root_directory = "/tmp/images"

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -8,7 +8,6 @@ type Tag struct {
 	// gorm.Model
 	ID        uint `gorm:"primarykey"`
 	Name      string
-	ParentID  uint
 	CreatedAt uint
 	UpdatedAt uint
 }

--- a/internal/db/tags.go
+++ b/internal/db/tags.go
@@ -144,3 +144,12 @@ func (client *FileTagClient) BatchDelete(ctx context.Context, tagIDs []uint, fil
 
 	return client.ORMClient.BatchDelete(ctx, fileTags)
 }
+
+func (client *FileTagClient) DeleteByTagIDs(ctx context.Context, tagIDs []uint) error {
+	if len(tagIDs) == 0 {
+		return nil
+	}
+	return client.getTransaction(ctx).
+		Where("tag_id IN ?", tagIDs).
+		Delete(&FileTag{}).Error
+}

--- a/internal/db/tags_test.go
+++ b/internal/db/tags_test.go
@@ -225,6 +225,53 @@ func TestFileTagClient_FindAllByTagIDs(t *testing.T) {
 	})
 }
 
+func TestFileTagClient_DeleteByTagIDs(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, FileTag{}, File{}, Tag{})
+
+	tags := []Tag{
+		{ID: 8501, Name: "tag1"},
+		{ID: 8502, Name: "tag2"},
+	}
+	files := []File{
+		{ID: 8510, ParentID: 0, Name: "img1.jpg", Type: FileTypeImage},
+		{ID: 8520, ParentID: 0, Name: "img2.jpg", Type: FileTypeImage},
+	}
+	fileTags := []FileTag{
+		{TagID: 8501, FileID: 8510, AddedBy: FileTagAddedByUser},
+		{TagID: 8501, FileID: 8520, AddedBy: FileTagAddedByUser},
+		{TagID: 8502, FileID: 8510, AddedBy: FileTagAddedByUser},
+		{TagID: 8502, FileID: 8520, AddedBy: FileTagAddedByUser},
+	}
+	LoadTestData(t, testClient, tags)
+	LoadTestData(t, testClient, files)
+	LoadTestData(t, testClient, fileTags)
+
+	ftClient := testClient.FileTag()
+	ctx := context.Background()
+
+	t.Run("empty tag IDs is a no-op", func(t *testing.T) {
+		err := ftClient.DeleteByTagIDs(ctx, nil)
+		assert.NoError(t, err)
+
+		remaining, err := ftClient.FindAllByTagIDs([]uint{8501, 8502})
+		assert.NoError(t, err)
+		assert.Len(t, remaining, 4)
+	})
+
+	t.Run("delete all file-tags for given tag IDs", func(t *testing.T) {
+		err := ftClient.DeleteByTagIDs(ctx, []uint{8501})
+		assert.NoError(t, err)
+
+		remaining, err := ftClient.FindAllByTagIDs([]uint{8501, 8502})
+		assert.NoError(t, err)
+		assert.Len(t, remaining, 2)
+		for _, ft := range remaining {
+			assert.Equal(t, uint(8502), ft.TagID)
+		}
+	})
+}
+
 func TestFileTagClient_BatchDelete(t *testing.T) {
 	testClient := NewTestClient(t)
 	testClient.Truncate(t, FileTag{}, File{}, Tag{})

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -128,9 +128,9 @@ func TestBatchImageExporter_Export(t *testing.T) {
 	for _, t := range []tag.Tag{
 		{ID: 1, Name: "tag1"},
 		{ID: 2, Name: "tag2"},
-		{ID: 3, Name: "tag10", ParentID: 1},
-		{ID: 4, Name: "tag11", ParentID: 1},
-		{ID: 5, Name: "tag100", ParentID: 3},
+		{ID: 3, Name: "tag10"},
+		{ID: 4, Name: "tag11"},
+		{ID: 5, Name: "tag100"},
 	} {
 		tagBuilder.Add(t)
 	}
@@ -205,13 +205,11 @@ func TestBatchImageExporter_Export(t *testing.T) {
 			},
 			wantImages: []string{
 				filepath.Join(includeTagDir, "train", fileCreator.BuildImageFile(11).Name),
-				filepath.Join(includeTagDir, "train", fileCreator.BuildImageFile(12).Name),
 				filepath.Join(includeTagDir, "train", fileCreator.BuildImageFile(101).Name),
 			},
 			wantMetadatas: []Metadata{
 				{FileName: fileCreator.BuildImageFile(11).Name, Tags: []float64{0, 1, 0, 0, 0, 0}},
-				// image12 inherits tag from directory but GetDirectTags returns only direct tags
-				{FileName: fileCreator.BuildImageFile(12).Name, Tags: []float64{0, 0, 0, 0, 0, 0}},
+				// image12 has no direct tags, so it's excluded from export
 				{FileName: fileCreator.BuildImageFile(101).Name, Tags: []float64{0, 0, 0, 0, 0, 1}},
 			},
 		},

--- a/internal/frontend/config_test.go
+++ b/internal/frontend/config_test.go
@@ -100,6 +100,43 @@ func TestConfigFrontendService_UpdateConfig(t *testing.T) {
 	assert.Equal(t, 60, diskConf.Backup.IdleMinutes)
 }
 
+func TestConfigFrontendService_GetDefaultConfig(t *testing.T) {
+	conf := config.Config{}
+	svc := NewConfigFrontendService(newConfigTestLogger(), conf)
+
+	got, err := svc.GetDefaultConfig(context.Background())
+	require.NoError(t, err)
+
+	// Verify defaults are populated
+	assert.NotEmpty(t, got.ImageRootDirectory)
+	assert.NotEmpty(t, got.ConfigDirectory)
+	assert.NotEmpty(t, got.LogDirectory)
+	assert.NotEmpty(t, got.BackupDirectory)
+	assert.Equal(t, 7, got.RetentionCount)
+	assert.Equal(t, 30, got.IdleMinutes)
+	assert.True(t, got.IdleBackupIncludeImages)
+}
+
+func TestConfigFrontendService_UpdateConfig_WriteError(t *testing.T) {
+	// Set HOME to an unwritable path so WriteConfig("", ...) fails
+	t.Setenv("HOME", "/nonexistent/path/that/does/not/exist")
+
+	conf := config.Config{
+		ImageRootDirectory: "/old/images",
+		ConfigDirectory:    "/old/config",
+	}
+
+	svc := NewConfigFrontendService(newConfigTestLogger(), conf)
+
+	newSettings := ConfigSettings{
+		ImageRootDirectory: "/new/images",
+		ConfigDirectory:    "/new/config",
+	}
+
+	err := svc.UpdateConfig(context.Background(), newSettings)
+	assert.Error(t, err, "UpdateConfig should fail when config file cannot be written")
+}
+
 func TestConfigFrontendService_RoundTrip(t *testing.T) {
 	tempHome := t.TempDir()
 	t.Setenv("HOME", tempHome)

--- a/internal/frontend/search_test.go
+++ b/internal/frontend/search_test.go
@@ -183,9 +183,9 @@ func TestSearchService_Search(t *testing.T) {
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
 					{ID: 2, Name: "tag 2"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 11, Name: "tag 11", ParentID: 1}, // a tag without an file
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 11, Name: "tag 11"}, // a tag without an file
+					{ID: 100, Name: "tag 100"},
 				},
 				insertFileTags: []db.FileTag{
 					{FileID: 1, TagID: 1},     // a top tag for a directory
@@ -237,16 +237,16 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 11, Name: "tag 11", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 11, Name: "tag 11"},
+					{ID: 100, Name: "tag 100"},
 
 					{ID: 2, Name: "tag 2"},
 				},
 				insertFileTags: []db.FileTag{
-					{FileID: 11, TagID: 2},   // a file with a different tag
-					{FileID: 12, TagID: 100}, // a file with a tag
-					{FileID: 101, TagID: 1},  // a file not in a parent directory
+					{FileID: 11, TagID: 2},  // a file with a different tag
+					{FileID: 12, TagID: 1},  // a file with the searched tag (will be excluded)
+					{FileID: 101, TagID: 1}, // a file not in a parent directory
 				},
 				want: SearchImagesResponse{
 					Images: []Image{
@@ -269,12 +269,10 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
 				},
 				insertFileTags: []db.FileTag{
-					{FileID: 11, TagID: 100},
-					{FileID: 12, TagID: 100},
+					{FileID: 11, TagID: 1},
+					{FileID: 12, TagID: 1},
 				},
 			},
 			{
@@ -291,11 +289,9 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
 				},
 				insertFileTags: []db.FileTag{
-					{FileID: 10, TagID: 100},
+					{FileID: 10, TagID: 1},
 				},
 			},
 		}
@@ -310,7 +306,7 @@ func TestSearchService_Search(t *testing.T) {
 				name: "Search a tag added to a file",
 				request: SearchImagesRequest{
 					DirectoryID: 10,
-					TagID:       1,
+					TagID:       10,
 				},
 				insertFiles: []db.File{
 					fileBuilder.BuildDBDirectory(1),
@@ -322,9 +318,9 @@ func TestSearchService_Search(t *testing.T) {
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
 					{ID: 2, Name: "tag 2"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 11, Name: "tag 11", ParentID: 1}, // a tag without an file
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 11, Name: "tag 11"}, // a tag without a file
+					{ID: 100, Name: "tag 100"},
 				},
 				insertFileTags: []db.FileTag{
 					{FileID: 11, TagID: 10},   // a tag for a direct file
@@ -357,13 +353,12 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 100, Name: "tag 100"},
 				},
 				insertFileTags: []db.FileTag{
-					{FileID: 10, TagID: 100},  // a tag added to a directory
-					{FileID: 100, TagID: 100}, // a tag in a different directory. No recursive search for a directory
-					{FileID: 2, TagID: 10},    // a tag added to a directory but it's in a different directory
+					{FileID: 10, TagID: 10},  // a tag added to a directory
+					{FileID: 2, TagID: 10},   // a tag added to a directory but it's in a different directory
 				},
 				want: SearchImagesResponse{
 					Images: []Image{
@@ -385,8 +380,8 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 100, Name: "tag 100"},
 				},
 				insertFileTags: []db.FileTag{
 					{FileID: 1, TagID: 10}, // a tag added to a directory
@@ -405,8 +400,8 @@ func TestSearchService_Search(t *testing.T) {
 				},
 				insertTags: []db.Tag{
 					{ID: 1, Name: "tag 1"},
-					{ID: 10, Name: "tag 10", ParentID: 1},
-					{ID: 100, Name: "tag 100", ParentID: 10},
+					{ID: 10, Name: "tag 10"},
+					{ID: 100, Name: "tag 100"},
 				},
 				insertFileTags: []db.FileTag{
 					{FileID: 1, TagID: 10}, // a tag added to a directory

--- a/internal/frontend/tag.go
+++ b/internal/frontend/tag.go
@@ -8,11 +8,8 @@ import (
 )
 
 type Tag struct {
-	ID       uint   `json:"id"`
-	Name     string `json:"name"`
-	FullName string `json:"fullName"`
-	ParentID uint   `json:"parentId"`
-	Children []Tag  `json:"children"`
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
 }
 
 type tagConverter struct {
@@ -23,52 +20,26 @@ func newTagConverter() tagConverter {
 }
 
 func (converter tagConverter) convert(t tag.Tag) Tag {
-	children := make([]Tag, len(t.Children))
-	for i, child := range t.Children {
-		children[i] = converter.convert(*child)
-	}
-	if len(children) == 0 {
-		children = nil
-	}
-
 	return Tag{
-		ID:       t.ID,
-		Name:     t.Name,
-		FullName: t.FullName,
-		ParentID: t.ParentID,
-		Children: children,
+		ID:   t.ID,
+		Name: t.Name,
 	}
 }
 
 type batchTagConverter struct {
-	tagTree   []tag.Tag
 	converter tagConverter
 }
 
-func newBatchTagConverterFromTagTree(tree []tag.Tag) batchTagConverter {
+func newBatchTagConverter() batchTagConverter {
 	return batchTagConverter{
-		tagTree:   tree,
 		converter: newTagConverter(),
 	}
 }
 
-func (batchConverter batchTagConverter) convert() []Tag {
+func (batchConverter batchTagConverter) convert(tags []tag.Tag) []Tag {
 	result := make([]Tag, 0)
-	for _, tag := range batchConverter.tagTree {
-		result = append(result, batchConverter.converter.convert(tag))
-	}
-	return result
-}
-
-func (converter batchTagConverter) convertToFlattenMap() map[uint]Tag {
-	result := make(map[uint]Tag)
-	for _, tag := range tag.ConvertTagsToMap(converter.tagTree) {
-		result[tag.ID] = Tag{
-			ID:       tag.ID,
-			Name:     tag.Name,
-			FullName: tag.FullName,
-			ParentID: tag.ParentID,
-		}
+	for _, t := range tags {
+		result = append(result, batchConverter.converter.convert(t))
 	}
 	return result
 }
@@ -88,7 +59,14 @@ func (service TagService) ReadAllMap() (map[uint]Tag, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ReadAllTags: %w", err)
 	}
-	return newBatchTagConverterFromTagTree(tags).convertToFlattenMap(), nil
+	result := make(map[uint]Tag)
+	for _, t := range tags {
+		result[t.ID] = Tag{
+			ID:   t.ID,
+			Name: t.Name,
+		}
+	}
+	return result, nil
 }
 
 func (service TagService) GetAll() ([]Tag, error) {
@@ -99,13 +77,11 @@ func (service TagService) GetAll() ([]Tag, error) {
 	if len(result) == 0 {
 		return nil, nil
 	}
-
-	return newBatchTagConverterFromTagTree(result).convert(), nil
+	return newBatchTagConverter().convert(result), nil
 }
 
 type TagStat struct {
 	FileCount              uint `json:"fileCount"`
-	IsAddedByAncestor      bool `json:"isAddedByAncestor"`
 	IsAddedBySelectedFiles bool `json:"isAddedBySelectedFiles"`
 }
 
@@ -127,7 +103,6 @@ func (service TagService) ReadTagsByFileIDs(
 	for tagID, tagStat := range batchImageTagChecker.GetStats() {
 		tagStats[tagID] = TagStat{
 			FileCount:              tagStat.Count,
-			IsAddedByAncestor:      tagStat.IsAddedByAncestor,
 			IsAddedBySelectedFiles: tagStat.IsAddedBySelectedFiles,
 		}
 	}

--- a/internal/frontend/tag_test.go
+++ b/internal/frontend/tag_test.go
@@ -19,21 +19,9 @@ type tagBuilder struct {
 func (builder *tagBuilder) BuildFrontendTag(id uint) Tag {
 	source := builder.Build(id)
 	require.NotZero(builder.t, source.ID)
-
-	children := make([]Tag, len(source.Children))
-	for i, child := range source.Children {
-		children[i] = builder.BuildFrontendTag(child.ID)
-	}
-	if len(children) == 0 {
-		children = nil
-	}
-
 	return Tag{
-		ID:       source.ID,
-		Name:     source.Name,
-		FullName: source.FullName,
-		ParentID: source.ParentID,
-		Children: children,
+		ID:   source.ID,
+		Name: source.Name,
 	}
 }
 
@@ -44,9 +32,9 @@ func TestTagService_GetAll(t *testing.T) {
 	builder := tester.newTagBuilder(t)
 	builder.Add(tag.Tag{ID: 1, Name: "tag1"}).
 		Add(tag.Tag{ID: 2, Name: "tag2"}).
-		Add(tag.Tag{ID: 11, Name: "child1 tag under tag1", ParentID: 1}).
-		Add(tag.Tag{ID: 12, Name: "child2 tag under tag1", ParentID: 1}).
-		Add(tag.Tag{ID: 111, Name: "child tag under child1", ParentID: 11})
+		Add(tag.Tag{ID: 11, Name: "child1 tag under tag1"}).
+		Add(tag.Tag{ID: 12, Name: "child2 tag under tag1"}).
+		Add(tag.Tag{ID: 111, Name: "child tag under child1"})
 
 	testCases := []struct {
 		name     string
@@ -65,6 +53,9 @@ func TestTagService_GetAll(t *testing.T) {
 			want: []Tag{
 				builder.BuildFrontendTag(1),
 				builder.BuildFrontendTag(2),
+				builder.BuildFrontendTag(11),
+				builder.BuildFrontendTag(12),
+				builder.BuildFrontendTag(111),
 			},
 		},
 		{
@@ -101,9 +92,9 @@ func TestTagService_ReadAllMap(t *testing.T) {
 	builder := tester.newTagBuilder(t)
 	builder.Add(tag.Tag{ID: 1, Name: "tag1"}).
 		Add(tag.Tag{ID: 2, Name: "tag2"}).
-		Add(tag.Tag{ID: 11, Name: "child1 tag under tag1", ParentID: 1}).
-		Add(tag.Tag{ID: 12, Name: "child2 tag under tag1", ParentID: 1}).
-		Add(tag.Tag{ID: 111, Name: "child tag under child1", ParentID: 11})
+		Add(tag.Tag{ID: 11, Name: "child1 tag under tag1"}).
+		Add(tag.Tag{ID: 12, Name: "child2 tag under tag1"}).
+		Add(tag.Tag{ID: 111, Name: "child tag under child1"})
 
 	testCases := []struct {
 		name     string
@@ -111,7 +102,7 @@ func TestTagService_ReadAllMap(t *testing.T) {
 		want     map[uint]Tag
 	}{
 		{
-			name: "Multiple tags with hierarchy",
+			name: "Multiple tags",
 			tagsInDB: []db.Tag{
 				builder.BuildDBTag(1),
 				builder.BuildDBTag(2),
@@ -120,34 +111,11 @@ func TestTagService_ReadAllMap(t *testing.T) {
 				builder.BuildDBTag(111),
 			},
 			want: map[uint]Tag{
-				1: {
-					ID:       1,
-					Name:     "tag1",
-					FullName: "tag1",
-				},
-				2: {
-					ID:       2,
-					Name:     "tag2",
-					FullName: "tag2",
-				},
-				11: {
-					ID:       11,
-					Name:     "child1 tag under tag1",
-					FullName: "tag1 > child1 tag under tag1",
-					ParentID: 1,
-				},
-				12: {
-					ID:       12,
-					Name:     "child2 tag under tag1",
-					FullName: "tag1 > child2 tag under tag1",
-					ParentID: 1,
-				},
-				111: {
-					ID:       111,
-					Name:     "child tag under child1",
-					FullName: "tag1 > child1 tag under tag1 > child tag under child1",
-					ParentID: 11,
-				},
+				1:   {ID: 1, Name: "tag1"},
+				2:   {ID: 2, Name: "tag2"},
+				11:  {ID: 11, Name: "child1 tag under tag1"},
+				12:  {ID: 12, Name: "child2 tag under tag1"},
+				111: {ID: 111, Name: "child tag under child1"},
 			},
 		},
 		{
@@ -176,12 +144,9 @@ func TestTagService_ReadAllMap_Error(t *testing.T) {
 	// Close the database to cause an error
 	dbClient.Truncate(t, &db.Tag{})
 
-	// Insert a tag with a circular parent reference that will cause
-	// an issue during reading. Actually, that's hard to trigger.
-	// Instead, let's just make sure the happy path with empty returns works.
+	// Test: ReadAllMap returns empty map for no tags (not an error)
 	service := tester.getTagService()
 
-	// Test: ReadAllMap returns empty map for no tags (not an error)
 	got, gotErr := service.ReadAllMap()
 	require.NoError(t, gotErr)
 	assert.Equal(t, map[uint]Tag{}, got)
@@ -246,18 +211,16 @@ func TestTagService_ReadTagsByFileIDs(t *testing.T) {
 				{ID: 100, Type: db.FileTypeImage, ParentID: 10, Name: "image file 100"},
 			},
 			insertFileTags: []db.FileTag{
-				{FileID: 1, TagID: 1},     // a tag for a top directory
-				{FileID: 2, TagID: 2},     // tag in directory 1 and 2
+				{FileID: 1, TagID: 1},     // a tag for a top directory (not requested)
+				{FileID: 2, TagID: 2},     // tag for file 2
 				{FileID: 3, TagID: 1},     // a file isn't included in a query
-				{FileID: 10, TagID: 11},   // a tag for a parent directory
+				{FileID: 10, TagID: 11},   // a tag for a parent directory (not requested)
 				{FileID: 100, TagID: 111}, // a tag for a direct file
 			},
 			want: ReadTagsByFileIDsResponse{
 				TagStats: map[uint]TagStat{
-					1:   {FileCount: 2, IsAddedByAncestor: true, IsAddedBySelectedFiles: false},
-					2:   {FileCount: 1, IsAddedByAncestor: false, IsAddedBySelectedFiles: true},
-					11:  {FileCount: 1, IsAddedByAncestor: true, IsAddedBySelectedFiles: false},
-					111: {FileCount: 1, IsAddedByAncestor: false, IsAddedBySelectedFiles: true},
+					2:   {FileCount: 1, IsAddedBySelectedFiles: true},
+					111: {FileCount: 1, IsAddedBySelectedFiles: true},
 				},
 			},
 		},

--- a/internal/image/directory_reader_test.go
+++ b/internal/image/directory_reader_test.go
@@ -147,6 +147,33 @@ func TestDirectoryReader_ReadImageFiles(t *testing.T) {
 	})
 }
 
+func TestDirectoryReader_ReadImageFiles_WithConversionError(t *testing.T) {
+	tester := newTester(t)
+	testDBClient := tester.dbClient
+
+	fileBuilder := tester.newFileCreator(t).
+		CreateDirectory(Directory{ID: 1, Name: "directory1"}).
+		CreateImage(ImageFile{ID: 10, Name: "image1.jpg", ParentID: 1}, TestImageFileJpeg)
+
+	t.Run("returns partial results and error when some images fail conversion", func(t *testing.T) {
+		testDBClient.Truncate(t, &db.File{})
+		db.LoadTestData(t, testDBClient, []db.File{
+			fileBuilder.BuildDBDirectory(1),
+			fileBuilder.BuildDBImageFile(10),
+			// Image 20 exists in DB but not on disk - will fail conversion
+			{ID: 20, Name: "missing_image.jpg", ParentID: 1, Type: db.FileTypeImage},
+		})
+
+		reader := tester.getDirectoryReader()
+		result, err := reader.ReadImageFiles(1)
+
+		// Should return an error because missing_image.jpg does not exist on disk
+		assert.Error(t, err)
+		// But should still return the valid image
+		assert.Len(t, result, 1)
+	})
+}
+
 func TestDirectoryReader_ReadImageFilesRecursively(t *testing.T) {
 	tester := newTester(t)
 	testDBClient := tester.dbClient
@@ -191,6 +218,34 @@ func TestDirectoryReader_ReadImageFilesRecursively(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, result, 1)
+	})
+}
+
+func TestDirectoryReader_ReadImageFilesRecursively_ErrorPropagation(t *testing.T) {
+	tester := newTester(t)
+	testDBClient := tester.dbClient
+
+	fileBuilder := tester.newFileCreator(t).
+		CreateDirectory(Directory{ID: 1, Name: "directory1"}).
+		CreateDirectory(Directory{ID: 2, Name: "sub_directory1", ParentID: 1}).
+		CreateImage(ImageFile{ID: 10, Name: "image1.jpg", ParentID: 1}, TestImageFileJpeg)
+
+	t.Run("returns error when child directory image fails", func(t *testing.T) {
+		testDBClient.Truncate(t, &db.File{})
+		db.LoadTestData(t, testDBClient, []db.File{
+			fileBuilder.BuildDBDirectory(1),
+			fileBuilder.BuildDBDirectory(2),
+			fileBuilder.BuildDBImageFile(10),
+			// Missing file on disk in sub_directory
+			{ID: 20, Name: "missing.jpg", ParentID: 2, Type: db.FileTypeImage},
+		})
+
+		reader := tester.getDirectoryReader()
+		dir, err := reader.ReadDirectory(1)
+		require.NoError(t, err)
+
+		_, err = reader.ReadImageFilesRecursively(dir)
+		assert.Error(t, err)
 	})
 }
 

--- a/internal/image/files_test.go
+++ b/internal/image/files_test.go
@@ -42,6 +42,19 @@ func TestCopy(t *testing.T) {
 		_, err := Copy(sourceFilePath, "/nonexistent/dir/dest.jpg")
 		assert.Error(t, err)
 	})
+
+	t.Run("source file not readable (permission denied)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		sourceFilePath := filepath.Join(tmpDir, "unreadable.jpg")
+		require.NoError(t, os.WriteFile(sourceFilePath, []byte("test data"), 0644))
+		require.NoError(t, os.Chmod(sourceFilePath, 0000))
+		t.Cleanup(func() {
+			os.Chmod(sourceFilePath, 0644)
+		})
+
+		_, err := Copy(sourceFilePath, filepath.Join(tmpDir, "dest.jpg"))
+		assert.Error(t, err)
+	})
 }
 
 func TestIsSupportedImageFile(t *testing.T) {

--- a/internal/import_images/batch_images_test.go
+++ b/internal/import_images/batch_images_test.go
@@ -90,10 +90,10 @@ func TestBatchImageImporter_importImageFiles(t *testing.T) {
 			},
 			wantInsertTags: dbTagBuilder.BuildTags(t,
 				db.Tag{ID: 1, Name: "Test 1"},
-				db.Tag{ID: 2, Name: "Test 10", ParentID: 1},
-				db.Tag{ID: 3, Name: "Test 100", ParentID: 2},
+				db.Tag{ID: 2, Name: "Test 10"},
+				db.Tag{ID: 3, Name: "Test 100"},
 				db.Tag{ID: 4, Name: "Test 2"},
-				db.Tag{ID: 5, Name: "Test 20", ParentID: 4},
+				db.Tag{ID: 5, Name: "Test 20"},
 			),
 			wantInsertFileTags: []db.FileTag{
 				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 3, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 3),

--- a/internal/import_images/batch_tag.go
+++ b/internal/import_images/batch_tag.go
@@ -25,9 +25,15 @@ func (batchImporter batchTagImporter) importTags(
 	ctx context.Context,
 	importedImages []importImage,
 ) error {
-	rootTag, err := batchImporter.tagReader.ReadRootNode()
+	allTags, err := batchImporter.tagReader.ReadAllTags()
 	if err != nil {
-		return fmt.Errorf("tagReader.ReadAllTagTree: %w", err)
+		return fmt.Errorf("tagReader.ReadAllTags: %w", err)
+	}
+
+	// Build a name-to-tag map for dedup
+	tagByName := make(map[string]*tag.Tag)
+	for i := range allTags {
+		tagByName[allTags[i].Name] = &allTags[i]
 	}
 
 	tagORMClient := batchImporter.dbClient.Tag()
@@ -41,7 +47,6 @@ OUTER_LOOP:
 			continue
 		}
 
-		// because tag can be created from a previous image, this cannot run concurrently
 		for _, t := range importedImage.xmp.RDF.TagsList {
 			if strings.TrimSpace(t) == "" {
 				continue OUTER_LOOP
@@ -51,47 +56,39 @@ OUTER_LOOP:
 				continue
 			}
 
-			// find existing tags by names
-			parent := &rootTag
-			index := 0
-			for ; index < len(importedTags); index++ {
-				currentTag := parent.FindChildByName(importedTags[index])
-				if currentTag == nil {
-					// Not found
-					break
-				}
-
-				parent = currentTag
-			}
-
-			for i := index; i < len(importedTags); i++ {
-				if importedTags[i] == "" {
+			// Create all tags in the path as flat tags
+			for _, tagName := range importedTags {
+				if tagName == "" {
 					continue
 				}
-
+				if _, exists := tagByName[tagName]; exists {
+					continue
+				}
 				dbTag := db.Tag{
-					Name:     importedTags[i],
-					ParentID: parent.ID,
+					Name: tagName,
 				}
 				if err := tagORMClient.Create(ctx, &dbTag); err != nil {
 					return fmt.Errorf("tagORMClient.Create: %w", err)
 				}
-
 				newTag := tag.Tag{
 					ID:   dbTag.ID,
-					Name: importedTags[i],
-					// parent id is set only the first new tag
-					ParentID: parent.ID,
+					Name: tagName,
 				}
-				// add new tag to a tree so that it can be searched later
-				parent.AddChild(&newTag)
-				parent = &newTag
+				tagByName[tagName] = &newTag
 			}
-			newFileTags = append(newFileTags, db.FileTag{
-				FileID:  importedImage.image.ID,
-				TagID:   parent.ID,
-				AddedBy: db.FileTagAddedByImport,
-			})
+
+			// Tag the image with the leaf tag (last in path)
+			leafTagName := importedTags[len(importedTags)-1]
+			if leafTagName == "" && len(importedTags) > 1 {
+				leafTagName = importedTags[len(importedTags)-2]
+			}
+			if leafTag, ok := tagByName[leafTagName]; ok {
+				newFileTags = append(newFileTags, db.FileTag{
+					FileID:  importedImage.image.ID,
+					TagID:   leafTag.ID,
+					AddedBy: db.FileTagAddedByImport,
+				})
+			}
 		}
 	}
 	if len(newFileTags) == 0 {

--- a/internal/import_images/batch_tag_test.go
+++ b/internal/import_images/batch_tag_test.go
@@ -13,8 +13,8 @@ func TestBatchTagImporter_importTags(t *testing.T) {
 	tester := newTester(t)
 	dbTagBuilder := tester.dbClient.NewTagBuilder().
 		AddTag(t, db.Tag{ID: 1, Name: "New Tag 1"}).
-		AddTag(t, db.Tag{ID: 2, Name: "New Tag 10", ParentID: 1}).
-		AddTag(t, db.Tag{ID: 3, Name: "New Tag 100", ParentID: 2})
+		AddTag(t, db.Tag{ID: 2, Name: "New Tag 10"}).
+		AddTag(t, db.Tag{ID: 3, Name: "New Tag 100"})
 
 	testCases := []struct {
 		name string
@@ -50,24 +50,24 @@ func TestBatchTagImporter_importTags(t *testing.T) {
 			name: "Import images with existing tags without an error",
 			insertTags: dbTagBuilder.BuildTags(t,
 				db.Tag{ID: 6, Name: "Existing Tag 1"},
-				db.Tag{ID: 7, Name: "Existing Tag 10", ParentID: 6},
-				db.Tag{ID: 8, Name: "Existing Tag 100", ParentID: 7},
+				db.Tag{ID: 7, Name: "Existing Tag 10"},
+				db.Tag{ID: 8, Name: "Existing Tag 100"},
 				db.Tag{ID: 9, Name: "Overlapped tag name 100"},
 			),
 			importImages: []importImage{
 				{
 					image: db.File{ID: 1},
 					xmp: &XMP{RDF: RDF{TagsList: []string{
-						// existing tags
+						// existing tags - leaf tag is "Existing Tag 100"
 						"Existing Tag 1/Existing Tag 10/Existing Tag 100",
-						// use the same tag with the root tag
+						// "Overlapped tag name 100" already exists as flat tag
 						"Existing Tag 1/New Tag 10/Overlapped tag name 100",
 					}}},
 				},
 				{
 					image: db.File{ID: 2},
 					xmp: &XMP{RDF: RDF{TagsList: []string{
-						// use the same tag from the previous tag
+						// "New Tag 10" was created above, "New Tag 100" is new
 						"Existing Tag 1/New Tag 10/New Tag 100",
 					}}},
 				},
@@ -77,15 +77,15 @@ func TestBatchTagImporter_importTags(t *testing.T) {
 				dbTagBuilder.Build(t, 7),
 				dbTagBuilder.Build(t, 8),
 				dbTagBuilder.Build(t, 9),
-				// in the previous test, tags with id 3-5 are created
-				dbTagBuilder.AddTag(t, db.Tag{ID: 10, Name: "New Tag 10", ParentID: 6}).Build(t, 10),
-				dbTagBuilder.AddTag(t, db.Tag{ID: 11, Name: "Overlapped tag name 100", ParentID: 10}).Build(t, 11),
-				dbTagBuilder.AddTag(t, db.Tag{ID: 12, Name: "New Tag 100", ParentID: 10}).Build(t, 12),
+				// "New Tag 10" is not in pre-inserted tags, so it gets created
+				dbTagBuilder.AddTag(t, db.Tag{ID: 10, Name: "New Tag 10"}).Build(t, 10),
+				// "New Tag 100" is not in pre-inserted tags, so it gets created
+				dbTagBuilder.AddTag(t, db.Tag{ID: 11, Name: "New Tag 100"}).Build(t, 11),
 			},
 			wantInsertFileTags: []db.FileTag{
 				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 8, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 8),
-				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 11, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 11),
-				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 2, TagID: 12, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 2, 12),
+				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 9, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 9),
+				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 2, TagID: 11, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 2, 11),
 			},
 		},
 		{
@@ -126,11 +126,11 @@ func TestBatchTagImporter_importTags(t *testing.T) {
 				},
 			},
 			wantInsertTags: dbTagBuilder.BuildTags(t,
-				db.Tag{ID: 13, Name: "Tag A"},
-				db.Tag{ID: 14, Name: "Tag B", ParentID: 13},
+				db.Tag{ID: 12, Name: "Tag A"},
+				db.Tag{ID: 13, Name: "Tag B"},
 			),
 			wantInsertFileTags: []db.FileTag{
-				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 14, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 14),
+				dbTagBuilder.AddFileTag(t, db.FileTag{FileID: 1, TagID: 13, AddedBy: db.FileTagAddedByImport}).BuildFileTag(t, 1, 13),
 			},
 		},
 	}

--- a/internal/search/runner_test.go
+++ b/internal/search/runner_test.go
@@ -253,7 +253,7 @@ func TestSearchImages(t *testing.T) {
 		assert.Empty(t, result)
 	})
 
-	t.Run("search with child tag finds images tagged with descendants", func(t *testing.T) {
+	t.Run("search by tag only finds images directly tagged", func(t *testing.T) {
 		env.truncate(t)
 
 		db.LoadTestData(t, env.dbClient, []db.File{
@@ -262,10 +262,10 @@ func TestSearchImages(t *testing.T) {
 			fileCreator.BuildDBImageFile(11),
 		})
 		db.LoadTestData(t, env.dbClient, []db.Tag{
-			{ID: 1, Name: "parent-tag"},
-			{ID: 2, Name: "child-tag", ParentID: 1},
+			{ID: 1, Name: "tag-a"},
+			{ID: 2, Name: "tag-b"},
 		})
-		// Image 10 is tagged with child tag, image 11 with parent tag
+		// Image 10 is tagged with tag-b, image 11 with tag-a
 		db.LoadTestData(t, env.dbClient, []db.FileTag{
 			{TagID: 2, FileID: 10, AddedBy: db.FileTagAddedByUser},
 			{TagID: 1, FileID: 11, AddedBy: db.FileTagAddedByUser},
@@ -273,17 +273,11 @@ func TestSearchImages(t *testing.T) {
 
 		runner := env.newRunner()
 
-		// Search by parent tag (ID=1) finds both since child tags are included
+		// Search by tag 1 only finds image 11 (directly tagged)
 		result, err := runner.SearchImages(context.Background(), 1, false, 0)
 		require.NoError(t, err)
-		require.Len(t, result, 2)
-
-		resultIDs := make([]uint, len(result))
-		for i, img := range result {
-			resultIDs[i] = img.ID
-		}
-		assert.Contains(t, resultIDs, uint(10))
-		assert.Contains(t, resultIDs, uint(11))
+		require.Len(t, result, 1)
+		assert.Equal(t, uint(11), result[0].ID)
 	})
 }
 

--- a/internal/tag/frontend.go
+++ b/internal/tag/frontend.go
@@ -99,27 +99,14 @@ func (service TagFrontendService) UpdateName(ctx context.Context, id uint, name 
 
 func (service TagFrontendService) GetTagFileCount(tagID uint) (uint, error) {
 	fileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{tagID})
-	if err != nil {
-		return 0, fmt.Errorf("FileTag.FindAllByTagIDs: %w", err)
-	}
-	return uint(len(fileTags)), nil
+	return uint(len(fileTags)), err
 }
 
 func (service TagFrontendService) DeleteTag(ctx context.Context, tagID uint) error {
 	return db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
-		// Delete file-tag associations first
-		fileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{tagID})
-		if err != nil {
-			return fmt.Errorf("FileTag.FindAllByTagIDs: %w", err)
+		if err := service.dbClient.FileTag().DeleteByTagIDs(ctx, []uint{tagID}); err != nil {
+			return fmt.Errorf("FileTag.DeleteByTagIDs: %w", err)
 		}
-		if len(fileTags) > 0 {
-			fileIDs := fileTags.ToFileIDs()
-			if err := service.dbClient.FileTag().BatchDelete(ctx, []uint{tagID}, fileIDs); err != nil {
-				return fmt.Errorf("FileTag.BatchDelete: %w", err)
-			}
-		}
-
-		// Delete the tag itself
 		if err := service.dbClient.Tag().BatchDelete(ctx, []db.Tag{{ID: tagID}}); err != nil {
 			return fmt.Errorf("Tag.BatchDelete: %w", err)
 		}
@@ -148,41 +135,37 @@ func (service TagFrontendService) MergeTags(ctx context.Context, sourceTagID uin
 			return fmt.Errorf("FileTag.FindAllByTagIDs for source: %w", err)
 		}
 
-		if len(sourceFileTags) > 0 {
-			// Get existing file associations for target tag to avoid duplicates
-			targetFileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{targetTagID})
-			if err != nil {
-				return fmt.Errorf("FileTag.FindAllByTagIDs for target: %w", err)
-			}
-			targetFileIDSet := make(map[uint]bool)
-			for _, ft := range targetFileTags {
-				targetFileIDSet[ft.FileID] = true
-			}
+		// Get existing file associations for target tag to avoid duplicates
+		targetFileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{targetTagID})
+		if err != nil {
+			return fmt.Errorf("FileTag.FindAllByTagIDs for target: %w", err)
+		}
+		targetFileIDSet := make(map[uint]bool)
+		for _, ft := range targetFileTags {
+			targetFileIDSet[ft.FileID] = true
+		}
 
-			// Create new file-tag associations for the target tag (skip duplicates)
-			newFileTags := make([]db.FileTag, 0)
-			for _, ft := range sourceFileTags {
-				if targetFileIDSet[ft.FileID] {
-					continue // target already has this file
-				}
-				newFileTags = append(newFileTags, db.FileTag{
-					TagID:   targetTagID,
-					FileID:  ft.FileID,
-					AddedBy: ft.AddedBy,
-				})
+		// Create new file-tag associations for the target tag (skip duplicates)
+		newFileTags := make([]db.FileTag, 0)
+		for _, ft := range sourceFileTags {
+			if targetFileIDSet[ft.FileID] {
+				continue // target already has this file
 			}
-			if len(newFileTags) > 0 {
-				fileTagClient := service.dbClient.FileTag()
-				if err := fileTagClient.BatchCreate(ctx, newFileTags); err != nil {
-					return fmt.Errorf("FileTag.BatchCreate: %w", err)
-				}
+			newFileTags = append(newFileTags, db.FileTag{
+				TagID:   targetTagID,
+				FileID:  ft.FileID,
+				AddedBy: ft.AddedBy,
+			})
+		}
+		if len(newFileTags) > 0 {
+			if err := service.dbClient.FileTag().BatchCreate(ctx, newFileTags); err != nil {
+				return fmt.Errorf("FileTag.BatchCreate: %w", err)
 			}
+		}
 
-			// Delete source tag's file associations
-			sourceFileIDs := sourceFileTags.ToFileIDs()
-			if err := service.dbClient.FileTag().BatchDelete(ctx, []uint{sourceTagID}, sourceFileIDs); err != nil {
-				return fmt.Errorf("FileTag.BatchDelete: %w", err)
-			}
+		// Delete source tag's file associations (no-op if none)
+		if err := service.dbClient.FileTag().DeleteByTagIDs(ctx, []uint{sourceTagID}); err != nil {
+			return fmt.Errorf("FileTag.DeleteByTagIDs: %w", err)
 		}
 
 		// Delete the source tag
@@ -220,7 +203,7 @@ func (service TagFrontendService) BatchUpdateTagsForFiles(ctx context.Context, f
 		return nil
 	}
 
-	err = db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
+	return db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
 		ormClient := service.dbClient.FileTag()
 		if len(deletedTagIDs) > 0 {
 			if err := ormClient.BatchDelete(ctx, deletedTagIDs, fileIDs); err != nil {
@@ -234,10 +217,6 @@ func (service TagFrontendService) BatchUpdateTagsForFiles(ctx context.Context, f
 		}
 		return nil
 	})
-	if err != nil {
-		return fmt.Errorf("db.NewTransaction: %w", err)
-	}
-	return nil
 }
 
 type SuggestTagsResponse struct {

--- a/internal/tag/frontend.go
+++ b/internal/tag/frontend.go
@@ -97,6 +97,103 @@ func (service TagFrontendService) UpdateName(ctx context.Context, id uint, name 
 	}, nil
 }
 
+func (service TagFrontendService) GetTagFileCount(tagID uint) (uint, error) {
+	fileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{tagID})
+	if err != nil {
+		return 0, fmt.Errorf("FileTag.FindAllByTagIDs: %w", err)
+	}
+	return uint(len(fileTags)), nil
+}
+
+func (service TagFrontendService) DeleteTag(ctx context.Context, tagID uint) error {
+	return db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
+		// Delete file-tag associations first
+		fileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{tagID})
+		if err != nil {
+			return fmt.Errorf("FileTag.FindAllByTagIDs: %w", err)
+		}
+		if len(fileTags) > 0 {
+			fileIDs := fileTags.ToFileIDs()
+			if err := service.dbClient.FileTag().BatchDelete(ctx, []uint{tagID}, fileIDs); err != nil {
+				return fmt.Errorf("FileTag.BatchDelete: %w", err)
+			}
+		}
+
+		// Delete the tag itself
+		if err := service.dbClient.Tag().BatchDelete(ctx, []db.Tag{{ID: tagID}}); err != nil {
+			return fmt.Errorf("Tag.BatchDelete: %w", err)
+		}
+		return nil
+	})
+}
+
+func (service TagFrontendService) MergeTags(ctx context.Context, sourceTagID uint, targetTagID uint) error {
+	if sourceTagID == targetTagID {
+		return fmt.Errorf("%w: source and target tags must be different", xerrors.ErrInvalidArgument)
+	}
+
+	return db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
+		// Verify both tags exist
+		tagClient := service.dbClient.Tag()
+		if _, err := tagClient.FindByValue(ctx, &db.Tag{ID: sourceTagID}); err != nil {
+			return fmt.Errorf("source tag not found: %w", err)
+		}
+		if _, err := tagClient.FindByValue(ctx, &db.Tag{ID: targetTagID}); err != nil {
+			return fmt.Errorf("target tag not found: %w", err)
+		}
+
+		// Get all file associations for source tag
+		sourceFileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{sourceTagID})
+		if err != nil {
+			return fmt.Errorf("FileTag.FindAllByTagIDs for source: %w", err)
+		}
+
+		if len(sourceFileTags) > 0 {
+			// Get existing file associations for target tag to avoid duplicates
+			targetFileTags, err := service.dbClient.FileTag().FindAllByTagIDs([]uint{targetTagID})
+			if err != nil {
+				return fmt.Errorf("FileTag.FindAllByTagIDs for target: %w", err)
+			}
+			targetFileIDSet := make(map[uint]bool)
+			for _, ft := range targetFileTags {
+				targetFileIDSet[ft.FileID] = true
+			}
+
+			// Create new file-tag associations for the target tag (skip duplicates)
+			newFileTags := make([]db.FileTag, 0)
+			for _, ft := range sourceFileTags {
+				if targetFileIDSet[ft.FileID] {
+					continue // target already has this file
+				}
+				newFileTags = append(newFileTags, db.FileTag{
+					TagID:   targetTagID,
+					FileID:  ft.FileID,
+					AddedBy: ft.AddedBy,
+				})
+			}
+			if len(newFileTags) > 0 {
+				fileTagClient := service.dbClient.FileTag()
+				if err := fileTagClient.BatchCreate(ctx, newFileTags); err != nil {
+					return fmt.Errorf("FileTag.BatchCreate: %w", err)
+				}
+			}
+
+			// Delete source tag's file associations
+			sourceFileIDs := sourceFileTags.ToFileIDs()
+			if err := service.dbClient.FileTag().BatchDelete(ctx, []uint{sourceTagID}, sourceFileIDs); err != nil {
+				return fmt.Errorf("FileTag.BatchDelete: %w", err)
+			}
+		}
+
+		// Delete the source tag
+		if err := tagClient.BatchDelete(ctx, []db.Tag{{ID: sourceTagID}}); err != nil {
+			return fmt.Errorf("Tag.BatchDelete: %w", err)
+		}
+
+		return nil
+	})
+}
+
 func (service TagFrontendService) BatchUpdateTagsForFiles(ctx context.Context, fileIDs []uint, addedTagIDs []uint, deletedTagIDs []uint) error {
 	fileTagClient := service.dbClient.FileTag()
 	fileTags, err := fileTagClient.FindAllByFileID(fileIDs)

--- a/internal/tag/frontend.go
+++ b/internal/tag/frontend.go
@@ -52,35 +52,17 @@ func (service TagFrontendService) CreateTopTag(name string) (Tag, error) {
 }
 
 type TagInput struct {
-	Name     string
-	ParentID uint
+	Name string
 }
 
 func (service TagFrontendService) Create(ctx context.Context, input TagInput) (Tag, error) {
 	tag := db.Tag{
-		Name:     input.Name,
-		ParentID: input.ParentID,
+		Name: input.Name,
 	}
-
-	err := db.NewTransaction(ctx, service.dbClient, func(ctx context.Context) error {
-		ormClient := service.dbClient.Tag()
-		_, err := ormClient.FindByValue(ctx, &db.Tag{
-			ID: input.ParentID,
-		})
-		if err != nil {
-			return fmt.Errorf("ormClient.FindByValue: %w", err)
-		}
-
-		if err := ormClient.Create(ctx, &tag); err != nil {
-			return fmt.Errorf("ormClient.Create: %w", err)
-		}
-
-		return nil
-	})
+	err := db.Create(service.dbClient, &tag)
 	if err != nil {
-		return Tag{}, err
+		return Tag{}, fmt.Errorf("db.Create: %w", err)
 	}
-
 	return Tag{
 		ID:   tag.ID,
 		Name: tag.Name,

--- a/internal/tag/frontend_test.go
+++ b/internal/tag/frontend_test.go
@@ -120,6 +120,134 @@ func TestTagFrontendService_UpdateName(t *testing.T) {
 	}
 }
 
+func TestTagFrontendService_GetTagFileCount(t *testing.T) {
+	tester := newTester(t)
+
+	// setup: create tags and file tags
+	require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+		{ID: 1, Name: "tag1"},
+		{ID: 2, Name: "tag2"},
+	}))
+	require.NoError(t, db.BatchCreate(tester.dbClient, []db.FileTag{
+		{TagID: 1, FileID: 100, AddedBy: db.FileTagAddedByUser},
+		{TagID: 1, FileID: 200, AddedBy: db.FileTagAddedByUser},
+	}))
+
+	service := tester.getFrontendService(frontendServiceMocks{})
+
+	count, err := service.GetTagFileCount(1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(2), count)
+
+	count, err = service.GetTagFileCount(2)
+	require.NoError(t, err)
+	assert.Equal(t, uint(0), count)
+}
+
+func TestTagFrontendService_DeleteTag(t *testing.T) {
+	tester := newTester(t)
+	tester.dbClient.Truncate(&db.Tag{}, &db.FileTag{})
+
+	require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+		{ID: 1, Name: "tag1"},
+		{ID: 2, Name: "tag2"},
+	}))
+	require.NoError(t, db.BatchCreate(tester.dbClient, []db.FileTag{
+		{TagID: 1, FileID: 100, AddedBy: db.FileTagAddedByUser},
+		{TagID: 1, FileID: 200, AddedBy: db.FileTagAddedByUser},
+	}))
+
+	ctx := context.Background()
+	service := tester.getFrontendService(frontendServiceMocks{})
+
+	// Delete tag with file associations
+	err := service.DeleteTag(ctx, 1)
+	require.NoError(t, err)
+
+	// Verify tag is deleted
+	tags, err := db.GetAll[db.Tag](tester.dbClient)
+	require.NoError(t, err)
+	assert.Len(t, tags, 1)
+	assert.Equal(t, uint(2), tags[0].ID)
+
+	// Verify file tags are deleted
+	fileTags, err := tester.dbClient.FileTag().FindAllByTagIDs([]uint{1})
+	require.NoError(t, err)
+	assert.Empty(t, fileTags)
+
+	// Delete tag without file associations
+	err = service.DeleteTag(ctx, 2)
+	require.NoError(t, err)
+
+	tags, err = db.GetAll[db.Tag](tester.dbClient)
+	require.NoError(t, err)
+	assert.Empty(t, tags)
+}
+
+func TestTagFrontendService_MergeTags(t *testing.T) {
+	tester := newTester(t)
+	ctx := context.Background()
+
+	t.Run("merge with file associations", func(t *testing.T) {
+		tester.dbClient.Truncate(&db.Tag{}, &db.FileTag{})
+
+		require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+			{ID: 1, Name: "source"},
+			{ID: 2, Name: "target"},
+		}))
+		require.NoError(t, db.BatchCreate(tester.dbClient, []db.FileTag{
+			{TagID: 1, FileID: 100, AddedBy: db.FileTagAddedByUser},
+			{TagID: 1, FileID: 200, AddedBy: db.FileTagAddedByUser},
+			{TagID: 2, FileID: 200, AddedBy: db.FileTagAddedByUser}, // overlap
+			{TagID: 2, FileID: 300, AddedBy: db.FileTagAddedByUser},
+		}))
+
+		service := tester.getFrontendService(frontendServiceMocks{})
+		err := service.MergeTags(ctx, 1, 2)
+		require.NoError(t, err)
+
+		// Source tag should be deleted
+		tags, err := db.GetAll[db.Tag](tester.dbClient)
+		require.NoError(t, err)
+		assert.Len(t, tags, 1)
+		assert.Equal(t, uint(2), tags[0].ID)
+
+		// Source file-tags should be deleted
+		sourceFileTags, err := tester.dbClient.FileTag().FindAllByTagIDs([]uint{1})
+		require.NoError(t, err)
+		assert.Empty(t, sourceFileTags)
+
+		// Target should have file 100 (transferred), 200 (already had), 300 (already had)
+		targetFileTags, err := tester.dbClient.FileTag().FindAllByTagIDs([]uint{2})
+		require.NoError(t, err)
+		assert.Len(t, targetFileTags, 3)
+	})
+
+	t.Run("merge same tag returns error", func(t *testing.T) {
+		service := tester.getFrontendService(frontendServiceMocks{})
+		err := service.MergeTags(ctx, 1, 1)
+		assert.Error(t, err)
+	})
+
+	t.Run("merge with no file associations", func(t *testing.T) {
+		tester.dbClient.Truncate(&db.Tag{}, &db.FileTag{})
+
+		require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+			{ID: 10, Name: "empty-source"},
+			{ID: 20, Name: "target"},
+		}))
+
+		service := tester.getFrontendService(frontendServiceMocks{})
+		err := service.MergeTags(ctx, 10, 20)
+		require.NoError(t, err)
+
+		tags, err := db.GetAll[db.Tag](tester.dbClient)
+		require.NoError(t, err)
+		assert.Len(t, tags, 1)
+		assert.Equal(t, uint(20), tags[0].ID)
+	})
+}
+
 func TestTagFrontendService_BatchUpdateTagsForFiles_NoChanges(t *testing.T) {
 	tester := newTester(t)
 	dbClient := tester.dbClient

--- a/internal/tag/frontend_test.go
+++ b/internal/tag/frontend_test.go
@@ -59,6 +59,7 @@ func TestTagFrontendService_Create(t *testing.T) {
 		assert.Equal(t, "mytag", got.Name)
 		assert.NotZero(t, got.ID)
 	})
+
 }
 
 func TestTagFrontendService_UpdateName(t *testing.T) {
@@ -245,6 +246,30 @@ func TestTagFrontendService_MergeTags(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, tags, 1)
 		assert.Equal(t, uint(20), tags[0].ID)
+	})
+
+	t.Run("merge with non-existent source tag returns error", func(t *testing.T) {
+		tester.dbClient.Truncate(&db.Tag{}, &db.FileTag{})
+
+		require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+			{ID: 200, Name: "target"},
+		}))
+
+		service := tester.getFrontendService(frontendServiceMocks{})
+		err := service.MergeTags(ctx, 999, 200)
+		assert.Error(t, err)
+	})
+
+	t.Run("merge with non-existent target tag returns error", func(t *testing.T) {
+		tester.dbClient.Truncate(&db.Tag{}, &db.FileTag{})
+
+		require.NoError(t, db.BatchCreate(tester.dbClient, []db.Tag{
+			{ID: 201, Name: "source"},
+		}))
+
+		service := tester.getFrontendService(frontendServiceMocks{})
+		err := service.MergeTags(ctx, 201, 999)
+		assert.Error(t, err)
 	})
 }
 

--- a/internal/tag/frontend_test.go
+++ b/internal/tag/frontend_test.go
@@ -38,7 +38,6 @@ func TestTagFrontendService_CreateTopTag(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, allTags, 1)
 		assert.Equal(t, "MyTag", allTags[0].Name)
-		assert.Equal(t, uint(0), allTags[0].ParentID)
 	})
 }
 
@@ -50,52 +49,16 @@ func TestTagFrontendService_Create(t *testing.T) {
 		dbClient: dbClient,
 	}
 
-	testCases := []struct {
-		name       string
-		insertTags []db.Tag
-		input      TagInput
-		wantName   string
-		wantErr    bool
-	}{
-		{
-			name: "create a child tag successfully",
-			insertTags: []db.Tag{
-				{ID: 1, Name: "parent"},
-			},
-			input: TagInput{
-				Name:     "child",
-				ParentID: 1,
-			},
-			wantName: "child",
-		},
-		{
-			name:       "parent not found returns error",
-			insertTags: nil,
-			input: TagInput{
-				Name:     "orphan",
-				ParentID: 999,
-			},
-			wantErr: true,
-		},
-	}
+	t.Run("create a tag successfully", func(t *testing.T) {
+		dbClient.Truncate(&db.Tag{})
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			dbClient.Truncate(&db.Tag{})
-			if len(tc.insertTags) > 0 {
-				require.NoError(t, db.BatchCreate(dbClient, tc.insertTags))
-			}
-
-			got, err := service.Create(context.Background(), tc.input)
-			if tc.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tc.wantName, got.Name)
-			assert.NotZero(t, got.ID)
+		got, err := service.Create(context.Background(), TagInput{
+			Name: "mytag",
 		})
-	}
+		require.NoError(t, err)
+		assert.Equal(t, "mytag", got.Name)
+		assert.NotZero(t, got.ID)
+	})
 }
 
 func TestTagFrontendService_UpdateName(t *testing.T) {
@@ -319,10 +282,10 @@ func TestTagFrontendService_SuggestTags(t *testing.T) {
 	tagBuilder := NewTestTagBuilder().
 		Add(Tag{ID: 1, Name: "tag1"}).
 		Add(Tag{ID: 2, Name: "tag2"}).
-		Add(Tag{ID: 10, Name: "tag 10", ParentID: 1}).
-		Add(Tag{ID: 20, Name: "tag 11", ParentID: 2}).
-		Add(Tag{ID: 100, Name: "tag 100", ParentID: 10}).
-		Add(Tag{ID: 200, Name: "tag 110", ParentID: 20})
+		Add(Tag{ID: 10, Name: "tag 10"}).
+		Add(Tag{ID: 20, Name: "tag 11"}).
+		Add(Tag{ID: 100, Name: "tag 100"}).
+		Add(Tag{ID: 200, Name: "tag 110"})
 
 	// tester.copyImageFile(t, "image.jpg", filepath.Join("Directory 1", "Directory 10", "image11.jpg"))
 	// tester.copyImageFile(t, "image.jpg", filepath.Join("Directory 1", "Directory 10", "Directory 100", "image101.jpg"))
@@ -353,10 +316,10 @@ func TestTagFrontendService_SuggestTags(t *testing.T) {
 			insertTags: []db.Tag{
 				{ID: 1, Name: "tag1"},
 				{ID: 2, Name: "tag2"},
-				{ID: 10, Name: "tag 10", ParentID: 1},
-				{ID: 20, Name: "tag 11", ParentID: 2},
-				{ID: 100, Name: "tag 100", ParentID: 10},
-				{ID: 200, Name: "tag 110", ParentID: 20},
+				{ID: 10, Name: "tag 10"},
+				{ID: 20, Name: "tag 11"},
+				{ID: 100, Name: "tag 100"},
+				{ID: 200, Name: "tag 110"},
 			},
 			insertDBFiles: []db.File{
 				{ID: 1, Name: "Directory 1", Type: db.FileTypeDirectory},
@@ -366,12 +329,12 @@ func TestTagFrontendService_SuggestTags(t *testing.T) {
 				{ID: 101, Name: "image101.jpg", Type: db.FileTypeImage, ParentID: 100},
 			},
 			insertFileTags: []db.FileTag{
-				{FileID: 11, TagID: 10},  // an image has a intermediate tag
-				{FileID: 100, TagID: 20}, // a directory has an intermediate tag
+				{FileID: 11, TagID: 10},  // an image has a tag
+				{FileID: 101, TagID: 20}, // an image has a tag
 			},
 			imageFileIDs: []uint{
 				11,  // an image has a tag
-				101, // a directory has a tag but not an image
+				101, // an image has a tag
 			},
 			setupMockClient: func(mock *tag_suggestionv1.MockTagSuggestionServiceClient) {
 				mock.EXPECT().
@@ -427,12 +390,11 @@ func TestTagFrontendService_SuggestTags(t *testing.T) {
 						{TagID: 100, Score: 0.7},
 						{TagID: 200, Score: 0.7},
 						{TagID: 2, Score: 0.6},
-						// a parent tag doesn't matter
-						{TagID: 1, Score: 0.5, HasDescendantTag: true},
+						{TagID: 1, Score: 0.5},
 					},
 					101: {
 						{TagID: 1, Score: 0.5},
-						{TagID: 2, Score: 0.4, HasDescendantTag: true},
+						{TagID: 2, Score: 0.4},
 						{TagID: 10, Score: 0.3},
 						{TagID: 20, Score: 0.2, HasTag: true},
 						{TagID: 100, Score: 0.1},
@@ -592,8 +554,8 @@ func TestTagFrontendService_AddSuggestedTags(t *testing.T) {
 			insertTags: []db.Tag{
 				{ID: 1, Name: "tag1"},
 				{ID: 2, Name: "tag2"},
-				{ID: 10, Name: "tag 10", ParentID: 1},
-				{ID: 100, Name: "tag 100", ParentID: 10},
+				{ID: 10, Name: "tag 10"},
+				{ID: 100, Name: "tag 100"},
 			},
 			insertFileTags: []db.FileTag{
 				{FileID: 11, TagID: 1, AddedBy: db.FileTagAddedByUser},
@@ -607,47 +569,32 @@ func TestTagFrontendService_AddSuggestedTags(t *testing.T) {
 			},
 		},
 		{
-			name: "request includes tags that are already added or of which children are added",
+			name: "request includes tags that are already added directly",
 			request: AddSuggestedTagsRequest{
 				SelectedTags: map[uint][]uint{
-					11:  {2},        // insert a tag successfully
-					98:  {1, 2},     // an image has a descendant tag
-					99:  {100},      // an image has a tag
-					998: {1},        // an ancestor has a descendant tag
-					999: {100, 200}, // an ancestor has a tag
+					11: {2},    // insert a tag successfully
+					98: {100},  // image has tag 100 directly - duplicated
+					99: {100},  // image has tag 100 directly - duplicated
 				},
 			},
 
 			insertFiles: slices.Concat(defaultInsertFiles, []db.File{
-				{ID: 10, Name: "Directory 10", Type: db.FileTypeDirectory, ParentID: 1},
 				{ID: 98, Name: "image98.jpg", Type: db.FileTypeImage, ParentID: 1},
 				{ID: 99, Name: "image99.jpg", Type: db.FileTypeImage, ParentID: 1},
-
-				{ID: 998, Name: "image998.jpg", Type: db.FileTypeImage, ParentID: 10},
-				{ID: 999, Name: "image999.jpg", Type: db.FileTypeImage, ParentID: 10},
 			}),
 			insertTags: []db.Tag{
 				{ID: 1, Name: "tag1"},
 				{ID: 2, Name: "tag2"},
-				{ID: 10, Name: "tag 10", ParentID: 1},
-				{ID: 20, Name: "tag 20", ParentID: 2},
-				{ID: 100, Name: "tag 100", ParentID: 10},
-				{ID: 200, Name: "tag 200", ParentID: 20},
+				{ID: 100, Name: "tag 100"},
 			},
 			insertFileTags: []db.FileTag{
-				{FileID: 10, TagID: 100, AddedBy: db.FileTagAddedBySuggestion},
-				{FileID: 10, TagID: 200, AddedBy: db.FileTagAddedBySuggestion},
 				{FileID: 98, TagID: 100, AddedBy: db.FileTagAddedBySuggestion},
-				{FileID: 98, TagID: 200, AddedBy: db.FileTagAddedBySuggestion},
 				{FileID: 99, TagID: 100, AddedBy: db.FileTagAddedBySuggestion},
-				{FileID: 99, TagID: 200, AddedBy: db.FileTagAddedBySuggestion},
 			},
 			want: AddSuggestedTagsResponse{
 				DuplicatedTags: map[uint][]uint{
-					98:  {1, 2},
-					99:  {100},
-					998: {1},
-					999: {100, 200},
+					98: {100},
+					99: {100},
 				},
 			},
 			wantInsertedFileTags: []db.FileTag{
@@ -658,15 +605,15 @@ func TestTagFrontendService_AddSuggestedTags(t *testing.T) {
 			name: "all tags are duplicated",
 			request: AddSuggestedTagsRequest{
 				SelectedTags: map[uint][]uint{
-					11: {10},
+					11: {100},
 					12: {100},
 				},
 			},
 			insertFiles: defaultInsertFiles,
 			insertTags: []db.Tag{
 				{ID: 1, Name: "tag1"},
-				{ID: 10, Name: "tag 10", ParentID: 1},
-				{ID: 100, Name: "tag 100", ParentID: 10},
+				{ID: 10, Name: "tag 10"},
+				{ID: 100, Name: "tag 100"},
 			},
 			insertFileTags: []db.FileTag{
 				{FileID: 11, TagID: 100, AddedBy: db.FileTagAddedByUser},
@@ -674,7 +621,7 @@ func TestTagFrontendService_AddSuggestedTags(t *testing.T) {
 			},
 			want: AddSuggestedTagsResponse{
 				DuplicatedTags: map[uint][]uint{
-					11: {10},
+					11: {100},
 					12: {100},
 				},
 			},

--- a/internal/tag/reader.go
+++ b/internal/tag/reader.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
-	"github.com/michael-freling/anime-image-viewer/internal/xslices"
-	"golang.org/x/sync/errgroup"
 )
 
 type Reader struct {
@@ -25,94 +23,26 @@ func NewReader(
 	}
 }
 
-func (reader Reader) ReadRootNode() (Tag, error) {
-	allTags, err := db.GetAll[db.Tag](reader.dbClient)
-	if err != nil {
-		return Tag{}, fmt.Errorf("db.GetAll: %w", err)
-	}
-	if len(allTags) == 0 {
-		return Tag{}, nil
-	}
-
-	childMap := make(map[uint][]Tag)
-	for _, t := range allTags {
-		if _, ok := childMap[t.ParentID]; ok {
-			continue
-		}
-		childMap[t.ParentID] = make([]Tag, 0)
-	}
-	tagMap := make(map[uint]Tag)
-	for _, t := range allTags {
-		tagMap[t.ID] = Tag{
-			ID:   t.ID,
-			Name: t.Name,
-		}
-
-		childMap[t.ParentID] = append(childMap[t.ParentID], tagMap[t.ID])
-	}
-
-	root := buildTagTree(tagMap, childMap, 0, nil)
-	return *root, nil
-}
-
-// depercated. Use ReadAllTagTree
 func (reader Reader) ReadAllTags() ([]Tag, error) {
 	allTags, err := db.GetAll[db.Tag](reader.dbClient)
 	if err != nil {
-		return nil, fmt.Errorf("ormClient.GetAll: %w", err)
+		return nil, fmt.Errorf("db.GetAll: %w", err)
 	}
 	if len(allTags) == 0 {
 		return nil, nil
 	}
-
-	childMap := make(map[uint][]Tag)
-	for _, t := range allTags {
-		if _, ok := childMap[t.ParentID]; ok {
-			continue
-		}
-		childMap[t.ParentID] = make([]Tag, 0)
-	}
-	tagMap := make(map[uint]Tag)
-	for _, t := range allTags {
-		tagMap[t.ID] = Tag{
+	result := make([]Tag, len(allTags))
+	for i, t := range allTags {
+		result[i] = Tag{
 			ID:   t.ID,
 			Name: t.Name,
 		}
-
-		childMap[t.ParentID] = append(childMap[t.ParentID], tagMap[t.ID])
 	}
-
-	return xslices.Map(buildTagTree(tagMap, childMap, 0, nil).Children, func(t *Tag) Tag {
-		return *t
-	}), nil
+	return result, nil
 }
 
 func (reader Reader) ReadDBTagRecursively(tagID uint) (db.FileTagList, error) {
-	allTags, err := reader.ReadAllTags()
-	if err != nil {
-		return nil, fmt.Errorf("reader.ReadAllTags: %w", err)
-	}
-	if len(allTags) == 0 {
-		return nil, nil
-	}
-
-	// find child tag
-	searchTagIDs := make([]uint, 0)
-	for _, tagTree := range allTags {
-		tag := tagTree.findChildByID(tagID)
-		if tag.ID == 0 {
-			continue
-		}
-		searchTagIDs = append(searchTagIDs, tag.ID)
-
-		descendantTags := tag.findDescendants()
-		for _, descendantTag := range descendantTags {
-			searchTagIDs = append(searchTagIDs, descendantTag.ID)
-		}
-	}
-
-	fileTags, err := reader.dbClient.FileTag().
-		FindAllByTagIDs(searchTagIDs)
+	fileTags, err := reader.dbClient.FileTag().FindAllByTagIDs([]uint{tagID})
 	if err != nil {
 		return nil, fmt.Errorf("db.FindAllByTagIDs: %w", err)
 	}
@@ -139,46 +69,9 @@ func (reader Reader) CreateBatchTagCheckerByFileIDs(
 	ctx context.Context,
 	fileIDs []uint,
 ) (BatchImageTagChecker, error) {
-	allTagMap := make(map[uint]Tag, 0)
-
-	eg, _ := errgroup.WithContext(ctx)
-	eg.Go(func() error {
-		allTags, err := reader.ReadAllTags()
-		if err != nil {
-			return fmt.Errorf("reader.ReadAllTags: %w", err)
-		}
-		allTagMap = ConvertTagsToMap(allTags)
-		return nil
-	})
-
-	var fileTags []db.FileTag
-	var fileIDToAncestors map[uint][]image.Directory
-	eg.Go(func() error {
-		var err error
-		fileIDToAncestors, err = reader.directoryReader.ReadAncestors(fileIDs)
-		if err != nil {
-			return fmt.Errorf("directoryReader.ReadAncestors: %w", err)
-		}
-		allFileIDs := make([]uint, 0)
-		for _, fileID := range fileIDs {
-			ancestors, ok := fileIDToAncestors[fileID]
-			if ok {
-				for _, ancestor := range ancestors {
-					allFileIDs = append(allFileIDs, ancestor.ID)
-				}
-			}
-			allFileIDs = append(allFileIDs, fileID)
-		}
-
-		fileTags, err = reader.dbClient.FileTag().
-			FindAllByFileID(allFileIDs)
-		if err != nil {
-			return fmt.Errorf("db.FindAllByValue: %w", err)
-		}
-		return nil
-	})
-	if err := eg.Wait(); err != nil {
-		return BatchImageTagChecker{}, fmt.Errorf("eg.Wait: %w", err)
+	fileTags, err := reader.dbClient.FileTag().FindAllByFileID(fileIDs)
+	if err != nil {
+		return BatchImageTagChecker{}, fmt.Errorf("db.FindAllByFileID: %w", err)
 	}
 	if len(fileTags) == 0 {
 		return BatchImageTagChecker{}, nil
@@ -186,18 +79,9 @@ func (reader Reader) CreateBatchTagCheckerByFileIDs(
 
 	imageTagCheckers := make([]ImageTagChecker, 0)
 	for _, fileID := range fileIDs {
-		ancestors := fileIDToAncestors[fileID]
-
-		ancestorMap := make(map[uint]image.Directory)
-		for _, ancestor := range ancestors {
-			ancestorMap[ancestor.ID] = ancestor
-		}
 		imageTagChecker := ImageTagChecker{
 			imageFileID: fileID,
-			ancestors:   ancestorMap,
-			allTags:     allTagMap,
 		}
-
 		hasImageFileTag := make(map[uint]db.FileTagAddedBy, 0)
 		for _, fileTag := range fileTags {
 			if fileID != fileTag.FileID {
@@ -206,18 +90,6 @@ func (reader Reader) CreateBatchTagCheckerByFileIDs(
 			hasImageFileTag[fileTag.TagID] = fileTag.AddedBy
 		}
 		imageTagChecker.imageFileTags = hasImageFileTag
-
-		tagsForAncestors := make(map[uint][]db.FileTagAddedBy, 0)
-		for _, fileTag := range fileTags {
-			for _, ancestor := range ancestors {
-				if ancestor.ID != fileTag.FileID {
-					continue
-				}
-				tagID := fileTag.TagID
-				tagsForAncestors[tagID] = append(tagsForAncestors[tagID], fileTag.AddedBy)
-			}
-		}
-		imageTagChecker.ancestorsTags = tagsForAncestors
 		imageTagCheckers = append(imageTagCheckers, imageTagChecker)
 	}
 

--- a/internal/tag/reader_test.go
+++ b/internal/tag/reader_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReader_ReadRootNode(t *testing.T) {
+func TestReader_ReadAllTags(t *testing.T) {
 	tester := newTester(t)
 	dbClient := tester.dbClient
 	reader := tester.getReader()
@@ -18,69 +18,31 @@ func TestReader_ReadRootNode(t *testing.T) {
 	testCases := []struct {
 		name       string
 		insertTags []db.Tag
-		wantTag    Tag
-		wantErr    bool
+		wantTags   []Tag
 	}{
 		{
-			name:       "no tags returns empty tag",
+			name:       "no tags returns nil",
 			insertTags: nil,
-			wantTag:    Tag{},
+			wantTags:   nil,
 		},
 		{
-			name: "single top-level tag",
+			name: "single tag",
 			insertTags: []db.Tag{
 				{ID: 1, Name: "tag1"},
 			},
-			wantTag: Tag{
-				Children: []*Tag{
-					{ID: 1, Name: "tag1", FullName: "tag1"},
-				},
+			wantTags: []Tag{
+				{ID: 1, Name: "tag1"},
 			},
 		},
 		{
-			name: "multiple top-level tags sorted by name",
+			name: "multiple tags",
 			insertTags: []db.Tag{
-				{ID: 1, Name: "zebra"},
-				{ID: 2, Name: "alpha"},
+				{ID: 1, Name: "alpha"},
+				{ID: 2, Name: "beta"},
 			},
-			wantTag: Tag{
-				Children: []*Tag{
-					{ID: 2, Name: "alpha", FullName: "alpha"},
-					{ID: 1, Name: "zebra", FullName: "zebra"},
-				},
-			},
-		},
-		{
-			name: "nested tags",
-			insertTags: []db.Tag{
-				{ID: 1, Name: "parent"},
-				{ID: 10, Name: "child", ParentID: 1},
-				{ID: 100, Name: "grandchild", ParentID: 10},
-			},
-			wantTag: Tag{
-				Children: []*Tag{
-					{
-						ID:       1,
-						Name:     "parent",
-						FullName: "parent",
-						Children: []*Tag{
-							{
-								ID:       10,
-								Name:     "child",
-								ParentID: 1,
-								FullName: "parent > child",
-								Children: []*Tag{
-									{
-										ID:       100,
-										Name:     "grandchild",
-										ParentID: 10,
-										FullName: "parent > child > grandchild",
-									},
-								},
-							},
-						},
-					},
-				},
+			wantTags: []Tag{
+				{ID: 1, Name: "alpha"},
+				{ID: 2, Name: "beta"},
 			},
 		},
 	}
@@ -92,15 +54,9 @@ func TestReader_ReadRootNode(t *testing.T) {
 				require.NoError(t, db.BatchCreate(dbClient, tc.insertTags))
 			}
 
-			got, err := reader.ReadRootNode()
-			if tc.wantErr {
-				assert.Error(t, err)
-				return
-			}
+			got, err := reader.ReadAllTags()
 			require.NoError(t, err)
-
-			// Compare IDs, names, and structure
-			assertTagTreeEqual(t, tc.wantTag, got)
+			assert.Equal(t, tc.wantTags, got)
 		})
 	}
 }
@@ -118,10 +74,10 @@ func TestReader_ReadDBTagRecursively(t *testing.T) {
 		wantFileTags   db.FileTagList
 	}{
 		{
-			name:         "no tags in db returns nil",
+			name:         "no file tags returns empty",
 			insertTags:   nil,
 			tagID:        1,
-			wantFileTags: nil,
+			wantFileTags: db.FileTagList{},
 		},
 		{
 			name: "tag not found returns empty",
@@ -132,10 +88,10 @@ func TestReader_ReadDBTagRecursively(t *testing.T) {
 			wantFileTags: db.FileTagList{},
 		},
 		{
-			name: "leaf tag with file tags",
+			name: "tag with file tags",
 			insertTags: []db.Tag{
 				{ID: 1, Name: "parent"},
-				{ID: 10, Name: "child", ParentID: 1},
+				{ID: 10, Name: "child"},
 			},
 			insertFileTags: []db.FileTag{
 				{FileID: 100, TagID: 10, AddedBy: db.FileTagAddedByUser},
@@ -148,11 +104,11 @@ func TestReader_ReadDBTagRecursively(t *testing.T) {
 			},
 		},
 		{
-			name: "parent tag includes descendants file tags",
+			name: "only returns file tags for the requested tag",
 			insertTags: []db.Tag{
 				{ID: 1, Name: "parent"},
-				{ID: 10, Name: "child", ParentID: 1},
-				{ID: 100, Name: "grandchild", ParentID: 10},
+				{ID: 10, Name: "child"},
+				{ID: 100, Name: "grandchild"},
 			},
 			insertFileTags: []db.FileTag{
 				{FileID: 1000, TagID: 1, AddedBy: db.FileTagAddedByUser},
@@ -162,8 +118,6 @@ func TestReader_ReadDBTagRecursively(t *testing.T) {
 			tagID: 1,
 			wantFileTags: db.FileTagList{
 				{FileID: 1000, TagID: 1, AddedBy: db.FileTagAddedByUser},
-				{FileID: 1001, TagID: 10, AddedBy: db.FileTagAddedByUser},
-				{FileID: 1002, TagID: 100, AddedBy: db.FileTagAddedByUser},
 			},
 		},
 	}
@@ -295,24 +249,5 @@ func TestReader_ReadDirectoryTags(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// assertTagTreeEqual compares two Tag trees ignoring unexported fields (parent pointer).
-func assertTagTreeEqual(t *testing.T, want, got Tag) {
-	t.Helper()
-	assert.Equal(t, want.ID, got.ID, "ID mismatch")
-	assert.Equal(t, want.Name, got.Name, "Name mismatch for ID=%d", want.ID)
-	assert.Equal(t, want.FullName, got.FullName, "FullName mismatch for ID=%d", want.ID)
-	assert.Equal(t, want.ParentID, got.ParentID, "ParentID mismatch for ID=%d", want.ID)
-
-	if want.Children == nil {
-		assert.Nil(t, got.Children, "expected nil Children for ID=%d", want.ID)
-		return
-	}
-
-	require.Len(t, got.Children, len(want.Children), "Children length mismatch for ID=%d", want.ID)
-	for i := range want.Children {
-		assertTagTreeEqual(t, *want.Children[i], *got.Children[i])
 	}
 }

--- a/internal/tag/suggestion.go
+++ b/internal/tag/suggestion.go
@@ -12,10 +12,9 @@ import (
 )
 
 type TagSuggestion struct {
-	TagID            uint    `json:"tagId"`
-	Score            float64 `json:"score"`
-	HasTag           bool    `json:"hasTag"`
-	HasDescendantTag bool    `json:"hasDescendantTag"`
+	TagID  uint    `json:"tagId"`
+	Score  float64 `json:"score"`
+	HasTag bool    `json:"hasTag"`
 }
 
 type SuggestionService struct {
@@ -121,10 +120,9 @@ func (service *SuggestionService) suggestTags(ctx context.Context, imageFileIDs 
 			}
 
 			suggestions = append(suggestions, TagSuggestion{
-				TagID:            uint(score.TagId),
-				Score:            score.Score,
-				HasTag:           batchTagChecker.HasTag(tag.ID),
-				HasDescendantTag: batchTagChecker.hasDecendantTag(tag.ID),
+				TagID:  uint(score.TagId),
+				Score:  score.Score,
+				HasTag: batchTagChecker.HasTag(tag.ID),
 			})
 		}
 		suggestionsForImageFiles[imageFileID] = suggestions
@@ -152,7 +150,7 @@ func (service *SuggestionService) addSuggestedTags(ctx context.Context, selected
 	for fileID, tags := range selectedTags {
 		tagChecker := batchTagChecker.GetTagCheckerForImageFileID(fileID)
 		for _, tagID := range tags {
-			if tagChecker.HasTag(tagID) || tagChecker.hasDecendantTag(tagID) {
+			if tagChecker.HasTag(tagID) {
 				if _, ok := duplicatedTags[fileID]; !ok {
 					duplicatedTags[fileID] = make([]uint, 0)
 				}

--- a/internal/tag/tags.go
+++ b/internal/tag/tags.go
@@ -1,98 +1,18 @@
 package tag
 
 import (
-	"fmt"
-	"slices"
-	"sort"
-
 	"github.com/michael-freling/anime-image-viewer/internal/db"
-	"github.com/michael-freling/anime-image-viewer/internal/image"
-	"github.com/michael-freling/anime-image-viewer/internal/xslices"
 )
 
 type Tag struct {
-	ID       uint   `json:"id"`
-	Name     string `json:"name"`
-	FullName string `json:"full_name,omitempty"`
-	ParentID uint   `json:"parentId,omitempty"`
-	parent   *Tag   `json:"-"`
-	Children []*Tag `json:"children,omitempty"`
-}
-
-func (tag Tag) fullName() string {
-	if tag.parent == nil {
-		return tag.Name
-	}
-	return fmt.Sprintf("%s > %s", tag.parent.fullName(), tag.Name)
-}
-
-func (tag *Tag) AddChild(child *Tag) {
-	tag.Children = append(tag.Children, child)
-}
-
-func (tag Tag) findChildByID(ID uint) Tag {
-	if tag.ID == ID {
-		return tag
-	}
-	for i := range tag.Children {
-		if child := tag.Children[i].findChildByID(ID); child.ID != 0 {
-			return child
-		}
-	}
-	return Tag{}
-}
-
-func (tag Tag) findDescendants() []Tag {
-	descendants := make([]Tag, 0)
-	for i := range tag.Children {
-		descendants = append(descendants, *tag.Children[i])
-		descendants = append(descendants, tag.Children[i].findDescendants()...)
-	}
-	return descendants
-}
-
-func (tag Tag) convertToFlattenMap() map[uint]Tag {
-	result := make(map[uint]Tag)
-	result[tag.ID] = tag
-	for _, child := range tag.Children {
-		for id, t := range child.convertToFlattenMap() {
-			result[id] = t
-		}
-	}
-	return result
-}
-
-func (node Tag) FindChildByName(name string) *Tag {
-	for _, tag := range node.Children {
-		if tag.Name == name {
-			return tag
-		}
-	}
-	return nil
-}
-
-func (node Tag) ConvertToFlattenMap() map[uint]Tag {
-	result := make(map[uint]Tag)
-	for _, tag := range node.Children {
-		// root is not a correct tag. Will be ignored
-		for id, t := range tag.convertToFlattenMap() {
-			result[id] = t
-		}
-	}
-	return result
+	ID   uint   `json:"id"`
+	Name string `json:"name"`
 }
 
 func ConvertTagsToMap(tags []Tag) map[uint]Tag {
 	result := make(map[uint]Tag)
 	for _, tag := range tags {
 		result[tag.ID] = tag
-		children := ConvertTagsToMap(xslices.Map(tag.Children, func(t *Tag) Tag {
-			return *t
-		}))
-		for id, child := range children {
-			result[id] = child
-		}
-		tag.Children = nil
 	}
 	return result
 }
@@ -103,72 +23,14 @@ func GetMaxTagID(tags []Tag) uint {
 		if tag.ID > maxID {
 			maxID = tag.ID
 		}
-
-		children := tag.findDescendants()
-		if len(children) == 0 {
-			continue
-		}
-		childMaxID := slices.Max(xslices.Map(children, func(tag Tag) uint {
-			return tag.ID
-		}))
-		if childMaxID > maxID {
-			maxID = childMaxID
-		}
 	}
 	return maxID
 }
 
-func buildTagTree(tagMap map[uint]Tag, childMap map[uint][]Tag, parentID uint, parent *Tag) *Tag {
-	t := tagMap[parentID]
-	if parent != nil && parent.ID != 0 {
-		t.ParentID = parent.ID
-		t.parent = parent
-	}
-	t.FullName = t.fullName()
-
-	if _, ok := childMap[parentID]; !ok {
-		return &t
-	}
-
-	t.Children = make([]*Tag, len(childMap[parentID]))
-	for i, child := range childMap[parentID] {
-		t.Children[i] = buildTagTree(tagMap, childMap, child.ID, &t)
-	}
-	sort.Slice(t.Children, func(i, j int) bool {
-		return t.Children[i].Name < t.Children[j].Name
-	})
-	return &t
-}
-
 type ImageTagChecker struct {
 	imageFileID uint
-
 	// tag id => bool (true if the image file has the tag)
 	imageFileTags map[uint]db.FileTagAddedBy
-
-	// directory id => an ancestor
-	ancestors map[uint]image.Directory
-
-	// tag id => an ids of ancestors
-	ancestorsTags map[uint][]db.FileTagAddedBy
-
-	allTags map[uint]Tag
-}
-
-func (checker ImageTagChecker) hasDecendantTag(tagID uint) bool {
-	tag, ok := checker.allTags[tagID]
-	if !ok {
-		return false
-	}
-	for _, descendant := range tag.findDescendants() {
-		if _, ok := checker.imageFileTags[descendant.ID]; ok {
-			return true
-		}
-		if _, ok := checker.ancestorsTags[descendant.ID]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func (checker ImageTagChecker) HasDirectTag() bool {
@@ -184,34 +46,18 @@ func (checker ImageTagChecker) GetDirectTags() []uint {
 }
 
 func (checker ImageTagChecker) HasAnyTag() bool {
-	return len(checker.imageFileTags) > 0 || len(checker.ancestorsTags) > 0
+	return len(checker.imageFileTags) > 0
 }
 
 func (checker ImageTagChecker) HasTag(tagID uint) bool {
-	if _, ok := checker.imageFileTags[tagID]; ok {
-		return true
-	}
-	if _, ok := checker.ancestorsTags[tagID]; ok {
-		return true
-	}
-	return false
+	_, ok := checker.imageFileTags[tagID]
+	return ok
 }
 
 func (checker ImageTagChecker) GetTagMap() map[uint]db.FileTagAddedBy {
 	tagCounts := make(map[uint]db.FileTagAddedBy)
 	for tagID, addedBy := range checker.imageFileTags {
 		tagCounts[tagID] = addedBy
-	}
-	for tagID, addedBys := range checker.ancestorsTags {
-		var resultAddedBy db.FileTagAddedBy
-		for _, addedBy := range addedBys {
-			if addedBy == db.FileTagAddedByUser {
-				resultAddedBy = db.FileTagAddedByUser
-				break
-			}
-			resultAddedBy = addedBy
-		}
-		tagCounts[tagID] = resultAddedBy
 	}
 	return tagCounts
 }
@@ -231,7 +77,6 @@ func (checker BatchImageTagChecker) GetTagCheckerForImageFileID(imageFileID uint
 
 type TagStatsForFiles struct {
 	Count                  uint
-	IsAddedByAncestor      bool
 	IsAddedBySelectedFiles bool
 }
 
@@ -247,9 +92,6 @@ func (checker BatchImageTagChecker) GetStats() map[uint]TagStatsForFiles {
 			newStat.Count = result[tagID].Count + 1
 			if _, ok := imageTagChecker.imageFileTags[tagID]; ok {
 				newStat.IsAddedBySelectedFiles = true
-			}
-			if _, ok := imageTagChecker.ancestorsTags[tagID]; ok {
-				newStat.IsAddedByAncestor = true
 			}
 			result[tagID] = newStat
 		}

--- a/internal/tag/tags_test.go
+++ b/internal/tag/tags_test.go
@@ -7,153 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTag_AddChild(t *testing.T) {
-	parent := &Tag{ID: 1, Name: "parent"}
-	child1 := &Tag{ID: 2, Name: "child1"}
-	child2 := &Tag{ID: 3, Name: "child2"}
-
-	parent.AddChild(child1)
-	assert.Len(t, parent.Children, 1)
-	assert.Equal(t, child1, parent.Children[0])
-
-	parent.AddChild(child2)
-	assert.Len(t, parent.Children, 2)
-	assert.Equal(t, child2, parent.Children[1])
-}
-
-func TestTag_findChildByID(t *testing.T) {
-	grandchild := &Tag{ID: 100, Name: "grandchild"}
-	child1 := &Tag{ID: 10, Name: "child1", Children: []*Tag{grandchild}}
-	child2 := &Tag{ID: 20, Name: "child2"}
-	root := Tag{ID: 1, Name: "root", Children: []*Tag{child1, child2}}
-
-	testCases := []struct {
-		name   string
-		id     uint
-		wantID uint
-	}{
-		{
-			name:   "find root itself",
-			id:     1,
-			wantID: 1,
-		},
-		{
-			name:   "find direct child",
-			id:     10,
-			wantID: 10,
-		},
-		{
-			name:   "find second direct child",
-			id:     20,
-			wantID: 20,
-		},
-		{
-			name:   "find grandchild",
-			id:     100,
-			wantID: 100,
-		},
-		{
-			name:   "not found returns empty tag",
-			id:     999,
-			wantID: 0,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := root.findChildByID(tc.id)
-			assert.Equal(t, tc.wantID, got.ID)
-		})
-	}
-}
-
-func TestTag_convertToFlattenMap(t *testing.T) {
-	grandchild := &Tag{ID: 100, Name: "grandchild"}
-	child1 := &Tag{ID: 10, Name: "child1", Children: []*Tag{grandchild}}
-	child2 := &Tag{ID: 20, Name: "child2"}
-	root := Tag{ID: 1, Name: "root", Children: []*Tag{child1, child2}}
-
-	result := root.convertToFlattenMap()
-
-	assert.Len(t, result, 4)
-	assert.Equal(t, uint(1), result[1].ID)
-	assert.Equal(t, uint(10), result[10].ID)
-	assert.Equal(t, uint(20), result[20].ID)
-	assert.Equal(t, uint(100), result[100].ID)
-}
-
-func TestTag_convertToFlattenMap_leafNode(t *testing.T) {
-	leaf := Tag{ID: 5, Name: "leaf"}
-	result := leaf.convertToFlattenMap()
-	assert.Len(t, result, 1)
-	assert.Equal(t, uint(5), result[5].ID)
-}
-
-func TestTag_FindChildByName(t *testing.T) {
-	child1 := &Tag{ID: 10, Name: "alpha"}
-	child2 := &Tag{ID: 20, Name: "beta"}
-	root := Tag{ID: 1, Name: "root", Children: []*Tag{child1, child2}}
-
-	testCases := []struct {
-		name     string
-		search   string
-		wantNil  bool
-		wantName string
-	}{
-		{
-			name:     "find existing child by name",
-			search:   "alpha",
-			wantName: "alpha",
-		},
-		{
-			name:     "find second child by name",
-			search:   "beta",
-			wantName: "beta",
-		},
-		{
-			name:    "not found returns nil",
-			search:  "gamma",
-			wantNil: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := root.FindChildByName(tc.search)
-			if tc.wantNil {
-				assert.Nil(t, got)
-			} else {
-				assert.NotNil(t, got)
-				assert.Equal(t, tc.wantName, got.Name)
-			}
-		})
-	}
-}
-
-func TestTag_ConvertToFlattenMap(t *testing.T) {
-	grandchild := &Tag{ID: 100, Name: "grandchild"}
-	child1 := &Tag{ID: 10, Name: "child1", Children: []*Tag{grandchild}}
-	child2 := &Tag{ID: 20, Name: "child2"}
-	// Root node (ID 0) should be excluded from the result
-	root := Tag{ID: 0, Name: "root", Children: []*Tag{child1, child2}}
-
-	result := root.ConvertToFlattenMap()
-
-	// Root is excluded, children and grandchildren are included
-	assert.Len(t, result, 3)
-	assert.Contains(t, result, uint(10))
-	assert.Contains(t, result, uint(20))
-	assert.Contains(t, result, uint(100))
-	_, hasRoot := result[0]
-	assert.False(t, hasRoot)
-}
-
-func TestTag_ConvertToFlattenMap_emptyChildren(t *testing.T) {
-	root := Tag{ID: 0, Name: "root"}
-	result := root.ConvertToFlattenMap()
-	assert.Len(t, result, 0)
-}
-
 func TestGetMaxTagID(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -180,36 +33,6 @@ func TestGetMaxTagID(t *testing.T) {
 				{ID: 1, Name: "tag1"},
 			},
 			want: 7,
-		},
-		{
-			name: "tags with children where child has max id",
-			tags: []Tag{
-				{
-					ID:   1,
-					Name: "tag1",
-					Children: []*Tag{
-						{ID: 10, Name: "child10", Children: []*Tag{
-							{ID: 100, Name: "grandchild100"},
-						}},
-					},
-				},
-				{ID: 5, Name: "tag5"},
-			},
-			want: 100,
-		},
-		{
-			name: "tags where parent has max id",
-			tags: []Tag{
-				{
-					ID:   200,
-					Name: "tag200",
-					Children: []*Tag{
-						{ID: 10, Name: "child10"},
-					},
-				},
-				{ID: 5, Name: "tag5"},
-			},
-			want: 200,
 		},
 	}
 
@@ -295,31 +118,16 @@ func TestImageTagChecker_HasAnyTag(t *testing.T) {
 	testCases := []struct {
 		name          string
 		imageFileTags map[uint]db.FileTagAddedBy
-		ancestorsTags map[uint][]db.FileTagAddedBy
 		want          bool
 	}{
 		{
-			name:          "has direct tag only",
+			name:          "has direct tag",
 			imageFileTags: map[uint]db.FileTagAddedBy{1: db.FileTagAddedByUser},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{},
-			want:          true,
-		},
-		{
-			name:          "has ancestor tag only",
-			imageFileTags: map[uint]db.FileTagAddedBy{},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{1: {db.FileTagAddedByUser}},
-			want:          true,
-		},
-		{
-			name:          "has both direct and ancestor tags",
-			imageFileTags: map[uint]db.FileTagAddedBy{1: db.FileTagAddedByUser},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{2: {db.FileTagAddedByUser}},
 			want:          true,
 		},
 		{
 			name:          "no tags at all",
 			imageFileTags: map[uint]db.FileTagAddedBy{},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{},
 			want:          false,
 		},
 	}
@@ -328,7 +136,6 @@ func TestImageTagChecker_HasAnyTag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			checker := ImageTagChecker{
 				imageFileTags: tc.imageFileTags,
-				ancestorsTags: tc.ancestorsTags,
 			}
 			assert.Equal(t, tc.want, checker.HasAnyTag())
 		})
@@ -339,7 +146,6 @@ func TestImageTagChecker_GetTagMap(t *testing.T) {
 	testCases := []struct {
 		name          string
 		imageFileTags map[uint]db.FileTagAddedBy
-		ancestorsTags map[uint][]db.FileTagAddedBy
 		want          map[uint]db.FileTagAddedBy
 	}{
 		{
@@ -348,54 +154,15 @@ func TestImageTagChecker_GetTagMap(t *testing.T) {
 				1: db.FileTagAddedByUser,
 				2: db.FileTagAddedBySuggestion,
 			},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{},
 			want: map[uint]db.FileTagAddedBy{
 				1: db.FileTagAddedByUser,
 				2: db.FileTagAddedBySuggestion,
 			},
 		},
 		{
-			name:          "ancestor tags only",
+			name:          "empty tags",
 			imageFileTags: map[uint]db.FileTagAddedBy{},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{
-				10: {db.FileTagAddedByUser},
-			},
-			want: map[uint]db.FileTagAddedBy{
-				10: db.FileTagAddedByUser,
-			},
-		},
-		{
-			name: "ancestor tag with user takes priority over suggestion",
-			imageFileTags: map[uint]db.FileTagAddedBy{},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{
-				10: {db.FileTagAddedBySuggestion, db.FileTagAddedByUser},
-			},
-			want: map[uint]db.FileTagAddedBy{
-				10: db.FileTagAddedByUser,
-			},
-		},
-		{
-			name: "ancestor tag with only suggestion",
-			imageFileTags: map[uint]db.FileTagAddedBy{},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{
-				10: {db.FileTagAddedBySuggestion},
-			},
-			want: map[uint]db.FileTagAddedBy{
-				10: db.FileTagAddedBySuggestion,
-			},
-		},
-		{
-			name: "mixed direct and ancestor tags",
-			imageFileTags: map[uint]db.FileTagAddedBy{
-				1: db.FileTagAddedByUser,
-			},
-			ancestorsTags: map[uint][]db.FileTagAddedBy{
-				10: {db.FileTagAddedBySuggestion},
-			},
-			want: map[uint]db.FileTagAddedBy{
-				1:  db.FileTagAddedByUser,
-				10: db.FileTagAddedBySuggestion,
-			},
+			want:          map[uint]db.FileTagAddedBy{},
 		},
 	}
 
@@ -403,7 +170,6 @@ func TestImageTagChecker_GetTagMap(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			checker := ImageTagChecker{
 				imageFileTags: tc.imageFileTags,
-				ancestorsTags: tc.ancestorsTags,
 			}
 			got := checker.GetTagMap()
 			assert.Equal(t, tc.want, got)
@@ -428,24 +194,10 @@ func TestBatchImageTagChecker_GetStats(t *testing.T) {
 				{
 					imageFileID:   1,
 					imageFileTags: map[uint]db.FileTagAddedBy{10: db.FileTagAddedByUser},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{},
 				},
 			},
 			want: map[uint]TagStatsForFiles{
-				10: {Count: 1, IsAddedBySelectedFiles: true, IsAddedByAncestor: false},
-			},
-		},
-		{
-			name: "single image with ancestor tags",
-			imageTagCheckers: []ImageTagChecker{
-				{
-					imageFileID:   1,
-					imageFileTags: map[uint]db.FileTagAddedBy{},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{10: {db.FileTagAddedByUser}},
-				},
-			},
-			want: map[uint]TagStatsForFiles{
-				10: {Count: 1, IsAddedBySelectedFiles: false, IsAddedByAncestor: true},
+				10: {Count: 1, IsAddedBySelectedFiles: true},
 			},
 		},
 		{
@@ -454,16 +206,14 @@ func TestBatchImageTagChecker_GetStats(t *testing.T) {
 				{
 					imageFileID:   1,
 					imageFileTags: map[uint]db.FileTagAddedBy{10: db.FileTagAddedByUser},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{},
 				},
 				{
 					imageFileID:   2,
-					imageFileTags: map[uint]db.FileTagAddedBy{},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{10: {db.FileTagAddedByUser}},
+					imageFileTags: map[uint]db.FileTagAddedBy{10: db.FileTagAddedByUser},
 				},
 			},
 			want: map[uint]TagStatsForFiles{
-				10: {Count: 2, IsAddedBySelectedFiles: true, IsAddedByAncestor: true},
+				10: {Count: 2, IsAddedBySelectedFiles: true},
 			},
 		},
 		{
@@ -472,18 +222,15 @@ func TestBatchImageTagChecker_GetStats(t *testing.T) {
 				{
 					imageFileID:   1,
 					imageFileTags: map[uint]db.FileTagAddedBy{10: db.FileTagAddedByUser},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{20: {db.FileTagAddedBySuggestion}},
 				},
 				{
 					imageFileID:   2,
 					imageFileTags: map[uint]db.FileTagAddedBy{30: db.FileTagAddedByUser},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{},
 				},
 			},
 			want: map[uint]TagStatsForFiles{
-				10: {Count: 1, IsAddedBySelectedFiles: true, IsAddedByAncestor: false},
-				20: {Count: 1, IsAddedBySelectedFiles: false, IsAddedByAncestor: true},
-				30: {Count: 1, IsAddedBySelectedFiles: true, IsAddedByAncestor: false},
+				10: {Count: 1, IsAddedBySelectedFiles: true},
+				30: {Count: 1, IsAddedBySelectedFiles: true},
 			},
 		},
 		{
@@ -492,7 +239,6 @@ func TestBatchImageTagChecker_GetStats(t *testing.T) {
 				{
 					imageFileID:   1,
 					imageFileTags: map[uint]db.FileTagAddedBy{},
-					ancestorsTags: map[uint][]db.FileTagAddedBy{},
 				},
 			},
 			want: nil,

--- a/internal/tag/testing.go
+++ b/internal/tag/testing.go
@@ -13,20 +13,6 @@ func NewTestTagBuilder() *TestTagBuilder {
 }
 
 func (b *TestTagBuilder) Add(tag Tag) *TestTagBuilder {
-	if tag.ParentID != 0 {
-		parent := b.tags[tag.ParentID]
-		tag.parent = parent
-		tag.FullName = parent.FullName + " > " + tag.Name
-
-		if parent.Children == nil {
-			parent.Children = []*Tag{}
-		}
-		parent.Children = append(parent.Children, &tag)
-	}
-	if tag.FullName == "" {
-		tag.FullName = tag.Name
-	}
-
 	b.tags[tag.ID] = &tag
 	return b
 }
@@ -38,8 +24,7 @@ func (b TestTagBuilder) Build(id uint) Tag {
 func (b TestTagBuilder) BuildDBTag(id uint) db.Tag {
 	tag := *b.tags[id]
 	return db.Tag{
-		ID:       tag.ID,
-		Name:     tag.Name,
-		ParentID: tag.ParentID,
+		ID:   tag.ID,
+		Name: tag.Name,
 	}
 }

--- a/internal/tag/testing_test.go
+++ b/internal/tag/testing_test.go
@@ -10,7 +10,7 @@ import (
 func TestTestTagBuilder_BuildDBTag(t *testing.T) {
 	builder := NewTestTagBuilder().
 		Add(Tag{ID: 1, Name: "parent"}).
-		Add(Tag{ID: 10, Name: "child", ParentID: 1})
+		Add(Tag{ID: 10, Name: "child"})
 
 	testCases := []struct {
 		name string
@@ -26,12 +26,11 @@ func TestTestTagBuilder_BuildDBTag(t *testing.T) {
 			},
 		},
 		{
-			name: "child tag with parent ID",
+			name: "another tag",
 			id:   10,
 			want: db.Tag{
-				ID:       10,
-				Name:     "child",
-				ParentID: 1,
+				ID:   10,
+				Name: "child",
 			},
 		},
 	}

--- a/plugins/tag-suggestion/src/tag.py
+++ b/plugins/tag-suggestion/src/tag.py
@@ -4,33 +4,16 @@ import json
 class Tag:
     id: int
     name: str
-    parent_id: int
-    full_name: str
-    children: list['Tag']
 
-    def __init__(self, id: int, name: str, full_name: str, parentId: int = 0, children: list['Tag'] = []):
+    def __init__(self, id: int, name: str, **kwargs):
         self.id = id
         self.name = name
-        self.parent_id = parentId
-        self.full_name = full_name
-        self.children = []
-        for child in children:
-            self.children.append(Tag(**child))
 
     def to_dict(self) -> dict[str, any]:
         return {
             'id': self.id,
             'name': self.name,
-            'full_name': self.full_name,
-            'children': [child.to_dict() for child in self.children]
         }
-
-    def flatten(self) -> dict[int, dict[str, any]]:
-        result = {}
-        result[self.id] = self.to_dict()
-        for child in self.children:
-            result.update(child.flatten())
-        return result
 
 
 class TagReader:
@@ -45,16 +28,13 @@ class TagReader:
         for value in jsonLine:
             tags.append(Tag(**value))
 
-        def flatten(tags: list[Tag]):
-            result = {}
-            for tag in tags:
-                result.update(tag.flatten())
-            return result
+        # Convert to list indexed by tag ID
+        if len(tags) == 0:
+            return ['']
 
-        dict = flatten(tags)
-        # Convert dict to list
-        result = ['' for _ in range(len(dict) + 1)]
-        for key, value in dict.items():
-            result[key] = value['name']
+        max_id = max(tag.id for tag in tags)
+        result = ['' for _ in range(max_id + 1)]
+        for tag in tags:
+            result[tag.id] = tag.name
 
         return result


### PR DESCRIPTION
## Summary
- **Flatten tag hierarchy** — remove parent-child relationships (ParentID, FullName, Children) from tags, simplifying the tag reader, checker, suggestion, search, import/export, and the Python tag-suggestion plugin. Closes #19.
- **Tag edit page improvements** — add delete and merge actions on each tag, plus a preview panel showing the selected tag's folders (as an ancestor tree) and images. Tags list gains a search box and alphabetical sort.
- **Reuse shared components** — the preview panel uses `ImageList`, `ImageWindow`, and `RichTreeView + ExplorerTreeItem` so it matches the search and folders pages.
- **Test coverage** — simplify `DeleteTag` / `MergeTags` via a new `FileTagClient.DeleteByTagIDs` helper, and add tests for non-existent source/target merge cases so total Go coverage stays at 90%.

## Test plan
- [x] Go tests pass (`go test -race ./internal/...`)
- [x] Go coverage ≥ 90%
- [x] TypeScript type-check passes
- [x] Frontend lint passes
- [x] Windows production build succeeds
- [ ] Manually verify tag list page shows flat tags
- [ ] Manually verify selecting a tag shows its preview (folders + images)
- [ ] Manually verify delete and merge actions work from the tag tree
- [ ] Manually verify tag selection works when editing images
- [ ] Manually verify search by tag and XMP import still work

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)