### PR TITLE
feat: detect and restore corrupted images with integrity tracking

### DIFF
--- a/frontend/__tests__/image-url.test.ts
+++ b/frontend/__tests__/image-url.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for image URL construction logic used by LazyImage and ImageCard.
+ *
+ * These tests verify:
+ * - The width query parameter is appended correctly (doubled for retina displays)
+ * - Paths with special characters are handled
+ * - The pattern used in the frontend to build image request URLs
+ */
+describe("image URL construction", () => {
+  /**
+   * Builds the image URL the same way LazyImage does:
+   *   src + "?" + new URLSearchParams({ width: String(width * 2) })
+   */
+  function buildImageUrl(src: string, width: number): string {
+    const query = new URLSearchParams();
+    query.append("width", (width * 2).toFixed(0));
+    return src + "?" + query.toString();
+  }
+
+  test("appends doubled width for retina displays", () => {
+    const url = buildImageUrl("/files/photos/image.jpg", 120);
+    expect(url).toBe("/files/photos/image.jpg?width=240");
+  });
+
+  test("handles width of zero", () => {
+    const url = buildImageUrl("/files/photos/image.jpg", 0);
+    expect(url).toBe("/files/photos/image.jpg?width=0");
+  });
+
+  test("handles path with spaces encoded", () => {
+    const url = buildImageUrl("/files/my%20photos/image.jpg", 100);
+    expect(url).toBe("/files/my%20photos/image.jpg?width=200");
+  });
+
+  test("handles deeply nested paths", () => {
+    const url = buildImageUrl("/files/a/b/c/d/image.png", 240);
+    expect(url).toBe("/files/a/b/c/d/image.png?width=480");
+  });
+
+  /**
+   * ImageCard uses a slightly different pattern: src + "?width=" + (2 * width).toFixed(0)
+   */
+  function buildImageCardUrl(src: string, width: number): string {
+    return src + "?width=" + (2 * width).toFixed(0);
+  }
+
+  test("ImageCard URL pattern matches LazyImage pattern", () => {
+    const src = "/files/photos/image.jpg";
+    const width = 240;
+    const lazyUrl = buildImageUrl(src, width);
+    const cardUrl = buildImageCardUrl(src, width);
+    expect(lazyUrl).toBe(cardUrl);
+  });
+});
+
+describe("image error response handling", () => {
+  test("HTTP 500 status indicates server error", () => {
+    // When the backend returns 500 for a corrupted image that cannot
+    // be restored, the response body contains the error message.
+    const status = 500;
+    const body = "image corrupted and restore failed: no valid backup found for file: photos/bad.jpg";
+
+    expect(status).toBe(500);
+    expect(body).toContain("image corrupted and restore failed");
+  });
+
+  test("HTTP 400 status indicates bad request", () => {
+    // When a file is not found and cannot be restored, the backend
+    // returns 400.
+    const status = 400;
+    expect(status).toBe(400);
+  });
+
+  test("HTTP 200 indicates successful serve (possibly after restore)", () => {
+    // A 200 response means the image was served successfully, even if
+    // a restore happened transparently on the backend.
+    const status = 200;
+    expect(status).toBe(200);
+  });
+});

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -109,7 +109,8 @@ func (s *BackupService) validateAndRestoreImages(ctx context.Context) {
 
 	err := filepath.Walk(imageRootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return err
+			s.logger.Warn("backup: cannot access path during validation", "path", path, "error", err)
+			return nil // skip inaccessible entries
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -13,11 +13,13 @@ import (
 	"time"
 
 	"github.com/michael-freling/anime-image-viewer/internal/config"
+	"github.com/michael-freling/anime-image-viewer/internal/image"
 )
 
 type BackupService struct {
-	logger *slog.Logger
-	config config.Config
+	logger         *slog.Logger
+	config         config.Config
+	restoreService *RestoreService
 }
 
 func NewBackupService(logger *slog.Logger, conf config.Config) *BackupService {
@@ -25,6 +27,13 @@ func NewBackupService(logger *slog.Logger, conf config.Config) *BackupService {
 		logger: logger,
 		config: conf,
 	}
+}
+
+// SetRestoreService sets the restore service used for pre-backup validation.
+// When set, the backup process will validate image files and attempt to restore
+// corrupted ones from existing backups before copying them into the new backup.
+func (s *BackupService) SetRestoreService(rs *RestoreService) {
+	s.restoreService = rs
 }
 
 // Backup creates a backup of the database and optionally images.
@@ -57,6 +66,11 @@ func (s *BackupService) Backup(ctx context.Context, destDir string, includeImage
 
 	// Optionally copy images
 	if includeImages {
+		// Validate and restore corrupted images before copying them into the backup
+		if s.restoreService != nil {
+			s.validateAndRestoreImages(ctx)
+		}
+
 		imagesDir := filepath.Join(backupDir, imagesDirName)
 		if err := copyDirectory(ctx, s.config.ImageRootDirectory, imagesDir); err != nil {
 			return "", fmt.Errorf("copy images: %w", err)
@@ -83,6 +97,66 @@ func (s *BackupService) Backup(ctx context.Context, destDir string, includeImage
 
 	s.logger.Info("backup completed", "directory", backupDir)
 	return backupDir, nil
+}
+
+// validateAndRestoreImages walks the image root directory, validates each image
+// file, and attempts to restore corrupted ones from existing backups.
+func (s *BackupService) validateAndRestoreImages(ctx context.Context) {
+	imageRootDir := s.config.ImageRootDirectory
+	s.logger.Info("backup: validating images before backup", "imageRootDir", imageRootDir)
+
+	var validated, corrupted, restored, failedRestore int
+
+	err := filepath.Walk(imageRootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		if info.IsDir() {
+			return nil
+		}
+
+		if valErr := image.ValidateImageFile(path); valErr != nil {
+			corrupted++
+			relPath, relErr := filepath.Rel(imageRootDir, path)
+			if relErr != nil {
+				s.logger.Warn("backup: failed to compute relative path for corrupted image",
+					"path", path, "error", relErr,
+				)
+				failedRestore++
+				validated++
+				return nil
+			}
+
+			s.logger.Warn("backup: corrupted image detected, attempting restore",
+				"path", path, "error", valErr,
+			)
+			if restoreErr := s.restoreService.RestoreSingleFile(ctx, relPath, imageRootDir); restoreErr != nil {
+				s.logger.Warn("backup: failed to restore corrupted image before backup",
+					"path", path, "error", restoreErr,
+				)
+				failedRestore++
+			} else {
+				s.logger.Info("backup: restored corrupted image before backup", "path", path)
+				restored++
+			}
+		}
+
+		validated++
+		return nil
+	})
+
+	if err != nil {
+		s.logger.Warn("backup: error walking image directory for validation", "error", err)
+	}
+
+	s.logger.Info("backup: image validation complete",
+		"validated", validated, "corrupted", corrupted, "restored", restored, "failedRestore", failedRestore,
+	)
 }
 
 // HasRecentBackup checks if a backup exists within the given duration.

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -597,6 +597,29 @@ func TestBackup_RetentionDoesNotDeleteNonBackupDirs(t *testing.T) {
 	assert.Equal(t, 1, backupDirCount, "should have exactly retention count backup dirs")
 }
 
+func TestBackup_BackupFolderCreationError(t *testing.T) {
+	conf := newTestConfig(t)
+	createFakeDB(t, conf)
+	logger := newTestLogger()
+	svc := NewBackupService(logger, conf)
+
+	// Create a file at exactly the timestamp-based backup dir path to block MkdirAll.
+	// Since timestamps vary, we override destDir to a controlled location.
+	destDir := t.TempDir()
+
+	// We cannot predict the exact timestamp, but we can create a file that blocks
+	// the timestamped subdirectory. Instead, make destDir itself read-only so the
+	// MkdirAll for the timestamped subfolder fails.
+	require.NoError(t, os.Chmod(destDir, 0555))
+	t.Cleanup(func() {
+		os.Chmod(destDir, 0755)
+	})
+
+	_, err := svc.Backup(context.Background(), destDir, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "create backup folder")
+}
+
 func TestCopyFile_SourceNotFound(t *testing.T) {
 	dst := filepath.Join(t.TempDir(), "dest.txt")
 	err := copyFile("/nonexistent/path/to/file", dst)
@@ -957,6 +980,173 @@ func TestBackup_ValidatesImagesBeforeCopying(t *testing.T) {
 		assert.DirExists(t, backupDir)
 	})
 
+	t.Run("skips valid images without errors", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Put only valid images in the image root directory
+		photosDir := filepath.Join(conf.ImageRootDirectory, "photos")
+		require.NoError(t, os.MkdirAll(photosDir, 0755))
+		createValidJPEG(t, filepath.Join(photosDir, "good1.jpg"))
+		createValidJPEG(t, filepath.Join(photosDir, "good2.jpg"))
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+
+		// Both images should be in the backup
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "photos", "good1.jpg"))
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "photos", "good2.jpg"))
+	})
+
+	t.Run("validates images in subdirectories", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Create nested directory structure with a mix of valid and corrupted
+		photosDir := filepath.Join(conf.ImageRootDirectory, "photos", "vacation")
+		require.NoError(t, os.MkdirAll(photosDir, 0755))
+		createValidJPEG(t, filepath.Join(photosDir, "good.jpg"))
+		require.NoError(t, os.WriteFile(filepath.Join(photosDir, "bad.jpg"), []byte("corrupt"), 0644))
+
+		// Create a pre-existing backup with valid copy
+		existingBackupDir := filepath.Join(conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00")
+		require.NoError(t, os.MkdirAll(existingBackupDir, 0755))
+		createValidJPEG(t, filepath.Join(existingBackupDir, imagesDirName, "photos", "vacation", "bad.jpg"))
+		metadata := BackupMetadata{
+			Version:          currentVersion,
+			CreatedAt:        time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+			IncludesImages:   true,
+			DatabaseFileName: databaseFileName,
+		}
+		require.NoError(t, writeMetadata(filepath.Join(existingBackupDir, metadataFileName), metadata))
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+		assert.DirExists(t, backupDir)
+	})
+
+	t.Run("context cancellation during validation", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Create many files so that the walk can detect cancellation
+		imageDir := conf.ImageRootDirectory
+		for i := range 50 {
+			subDir := filepath.Join(imageDir, fmt.Sprintf("dir_%d", i))
+			require.NoError(t, os.MkdirAll(subDir, 0755))
+			createValidJPEG(t, filepath.Join(subDir, "img.jpg"))
+		}
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Backup with cancelled context should fail during image copy (after validation aborts)
+		_, err := backupSvc.Backup(ctx, "", true)
+		require.Error(t, err)
+	})
+
+	t.Run("walk error during validation skips inaccessible entries", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Create a subdirectory that cannot be read plus a readable one
+		badDir := filepath.Join(conf.ImageRootDirectory, "no_access")
+		require.NoError(t, os.MkdirAll(badDir, 0755))
+		createValidJPEG(t, filepath.Join(badDir, "img.jpg"))
+		require.NoError(t, os.Chmod(badDir, 0000))
+		t.Cleanup(func() {
+			os.Chmod(badDir, 0755)
+		})
+
+		goodDir := filepath.Join(conf.ImageRootDirectory, "good")
+		require.NoError(t, os.MkdirAll(goodDir, 0755))
+		createValidJPEG(t, filepath.Join(goodDir, "img.jpg"))
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		// Validation should skip the inaccessible directory, and the backup should
+		// still work for accessible files. copyDirectory will also skip the bad dir.
+		// We accept an error or success depending on OS behavior for copyDirectory.
+		_, _ = backupSvc.Backup(context.Background(), "", true)
+		// The main assertion is that it does not panic.
+	})
+
+	t.Run("empty image directory with restore service", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// No images at all - validation should complete quickly
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+		assert.DirExists(t, backupDir)
+	})
+
+	t.Run("mixed valid and corrupted images across directories", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Create multiple directories with a mix of valid and corrupted images
+		for _, dir := range []string{"dir_a", "dir_b", "dir_c"} {
+			dirPath := filepath.Join(conf.ImageRootDirectory, dir)
+			require.NoError(t, os.MkdirAll(dirPath, 0755))
+			createValidJPEG(t, filepath.Join(dirPath, "ok.jpg"))
+		}
+		// Corrupt one image in dir_b
+		require.NoError(t, os.WriteFile(
+			filepath.Join(conf.ImageRootDirectory, "dir_b", "corrupt.jpg"),
+			[]byte("bad data"), 0644,
+		))
+
+		// Create backup with valid copy of the corrupt image
+		existingBackupDir := filepath.Join(conf.Backup.BackupDirectory, "backup_2024-06-01T10-00-00")
+		require.NoError(t, os.MkdirAll(existingBackupDir, 0755))
+		createValidJPEG(t, filepath.Join(existingBackupDir, imagesDirName, "dir_b", "corrupt.jpg"))
+		metadata := BackupMetadata{
+			Version:          currentVersion,
+			CreatedAt:        time.Date(2024, 6, 1, 10, 0, 0, 0, time.UTC),
+			IncludesImages:   true,
+			DatabaseFileName: databaseFileName,
+		}
+		require.NoError(t, writeMetadata(filepath.Join(existingBackupDir, metadataFileName), metadata))
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+
+		// All images should be in the backup
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "dir_a", "ok.jpg"))
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "dir_b", "ok.jpg"))
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "dir_b", "corrupt.jpg"))
+		assert.FileExists(t, filepath.Join(backupDir, imagesDirName, "dir_c", "ok.jpg"))
+	})
+
 	t.Run("backup without restore service skips validation", func(t *testing.T) {
 		conf := newTestConfig(t)
 		createFakeDB(t, conf)
@@ -974,6 +1164,43 @@ func TestBackup_ValidatesImagesBeforeCopying(t *testing.T) {
 		require.NoError(t, err)
 		assert.DirExists(t, backupDir)
 	})
+}
+
+func TestRestore_WithTargetDirectory(t *testing.T) {
+	conf := newTestConfig(t)
+	createFakeDB(t, conf)
+	logger := newTestLogger()
+	backupSvc := NewBackupService(logger, conf)
+	restoreSvc := NewRestoreService(logger, conf)
+
+	// Create images and back them up
+	createFakeImages(t, conf.ImageRootDirectory)
+	backupDir, err := backupSvc.Backup(context.Background(), "", true)
+	require.NoError(t, err)
+
+	// Restore to a target directory instead of the default locations
+	targetDir := filepath.Join(t.TempDir(), "restore-target")
+	err = restoreSvc.Restore(context.Background(), backupDir, RestoreOptions{
+		RestoreImages:   true,
+		TargetDirectory: targetDir,
+	})
+	require.NoError(t, err)
+
+	// Verify the DB was restored into the target directory
+	dbPath := filepath.Join(targetDir, string(conf.Environment)+"_v1.sqlite")
+	content, err := os.ReadFile(dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-sqlite-database-content", string(content))
+
+	// Verify images were restored into targetDir/images/
+	imgPath := filepath.Join(targetDir, "images", "photos", "img1.jpg")
+	content, err = os.ReadFile(imgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "fake-image-data-img1.jpg", string(content))
+
+	// Verify original image directory was NOT removed (since we used TargetDirectory)
+	_, err = os.Stat(conf.ImageRootDirectory)
+	assert.NoError(t, err, "original image directory should still exist when restoring to target directory")
 }
 
 func TestRestore_ConfigDirectoryCreation(t *testing.T) {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -890,6 +890,92 @@ func TestDeleteBackup_NonexistentPath(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestBackup_ValidatesImagesBeforeCopying(t *testing.T) {
+	t.Run("restores corrupted image before backup", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Put a corrupted image in the image root directory
+		photosDir := filepath.Join(conf.ImageRootDirectory, "photos")
+		require.NoError(t, os.MkdirAll(photosDir, 0755))
+		corruptedPath := filepath.Join(photosDir, "bad.jpg")
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("corrupted data"), 0644))
+
+		// Create a pre-existing backup with a valid copy of the same file
+		existingBackupDir := filepath.Join(conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00")
+		require.NoError(t, os.MkdirAll(existingBackupDir, 0755))
+		backupImagePath := filepath.Join(existingBackupDir, imagesDirName, "photos", "bad.jpg")
+		createValidJPEG(t, backupImagePath)
+		metadata := BackupMetadata{
+			Version:          currentVersion,
+			CreatedAt:        time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC),
+			IncludesImages:   true,
+			DatabaseFileName: databaseFileName,
+		}
+		require.NoError(t, writeMetadata(filepath.Join(existingBackupDir, metadataFileName), metadata))
+
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+
+		// The corrupted image should have been restored in the image root
+		// and the backup should contain the valid copy.
+		backedUpPath := filepath.Join(backupDir, imagesDirName, "photos", "bad.jpg")
+		_, err = os.Stat(backedUpPath)
+		assert.NoError(t, err, "backed-up image should exist")
+
+		// Also verify the original was restored
+		content, err := os.ReadFile(corruptedPath)
+		require.NoError(t, err)
+		assert.NotEqual(t, "corrupted data", string(content), "original image should have been restored")
+	})
+
+	t.Run("logs warning when restore fails", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Put a corrupted image in the image root directory
+		photosDir := filepath.Join(conf.ImageRootDirectory, "photos")
+		require.NoError(t, os.MkdirAll(photosDir, 0755))
+		corruptedPath := filepath.Join(photosDir, "bad.jpg")
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("corrupted data"), 0644))
+
+		// No backup exists, so restore will fail. The backup should still complete.
+		restoreSvc := NewRestoreService(logger, conf)
+		backupSvc := NewBackupService(logger, conf)
+		backupSvc.SetRestoreService(restoreSvc)
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+
+		// The backup directory should still exist
+		assert.DirExists(t, backupDir)
+	})
+
+	t.Run("backup without restore service skips validation", func(t *testing.T) {
+		conf := newTestConfig(t)
+		createFakeDB(t, conf)
+		logger := newTestLogger()
+
+		// Put a corrupted image
+		photosDir := filepath.Join(conf.ImageRootDirectory, "photos")
+		require.NoError(t, os.MkdirAll(photosDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(photosDir, "bad.jpg"), []byte("corrupted data"), 0644))
+
+		backupSvc := NewBackupService(logger, conf)
+		// No SetRestoreService call — validation should be skipped
+
+		backupDir, err := backupSvc.Backup(context.Background(), "", true)
+		require.NoError(t, err)
+		assert.DirExists(t, backupDir)
+	})
+}
+
 func TestRestore_ConfigDirectoryCreation(t *testing.T) {
 	conf := newTestConfig(t)
 	createFakeDB(t, conf)

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -2,12 +2,18 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 
 	"github.com/michael-freling/anime-image-viewer/internal/config"
+	"github.com/michael-freling/anime-image-viewer/internal/image"
+)
+
+var (
+	ErrNoValidBackup = errors.New("no valid backup found for file")
 )
 
 type RestoreService struct {
@@ -111,5 +117,71 @@ func (s *RestoreService) Restore(ctx context.Context, backupDir string, opts Res
 
 	s.logger.Info("restore completed", "backupDir", backupDir, "configDir", configDir, "imageDir", imageDir)
 	return nil
+}
+
+// RestoreSingleFile attempts to restore a single corrupted image file from the
+// newest available backup. relativeFilePath is the path of the image relative to
+// imageRootDir (e.g. "photos/vacation/beach.jpg"). The method iterates through
+// backups from newest to oldest, looking for a valid copy of the file.
+func (s *RestoreService) RestoreSingleFile(ctx context.Context, relativeFilePath string, imageRootDir string) error {
+	backupService := NewBackupService(s.logger, s.config)
+	backups, err := backupService.ListBackups()
+	if err != nil {
+		return fmt.Errorf("list backups: %w", err)
+	}
+
+	if len(backups) == 0 {
+		return fmt.Errorf("%w: %s (no backups exist)", ErrNoValidBackup, relativeFilePath)
+	}
+
+	for _, backup := range backups {
+		if !backup.IncludesImages {
+			s.logger.DebugContext(ctx, "skipping backup without images",
+				"backupPath", backup.Path,
+				"relativeFilePath", relativeFilePath,
+			)
+			continue
+		}
+
+		backupImagePath := filepath.Join(backup.Path, imagesDirName, relativeFilePath)
+
+		// Check if the file exists in this backup
+		if _, err := os.Stat(backupImagePath); err != nil {
+			s.logger.DebugContext(ctx, "file not found in backup",
+				"backupPath", backup.Path,
+				"backupImagePath", backupImagePath,
+				"relativeFilePath", relativeFilePath,
+			)
+			continue
+		}
+
+		// Validate the backup copy is not also corrupted
+		if err := image.ValidateImageFile(backupImagePath); err != nil {
+			s.logger.WarnContext(ctx, "backup copy is also corrupted",
+				"backupPath", backup.Path,
+				"backupImagePath", backupImagePath,
+				"error", err,
+			)
+			continue
+		}
+
+		// Copy the valid backup to the original location
+		destPath := filepath.Join(imageRootDir, relativeFilePath)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return fmt.Errorf("create parent directory for %s: %w", destPath, err)
+		}
+		if err := copyFile(backupImagePath, destPath); err != nil {
+			return fmt.Errorf("copy restored file: %w", err)
+		}
+
+		s.logger.InfoContext(ctx, "restored file from backup",
+			"relativeFilePath", relativeFilePath,
+			"backupPath", backup.Path,
+			"destPath", destPath,
+		)
+		return nil
+	}
+
+	return fmt.Errorf("%w: %s", ErrNoValidBackup, relativeFilePath)
 }
 

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -1,0 +1,197 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createValidJPEG creates a valid JPEG file at the given path.
+func createValidJPEG(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, color.RGBA{R: 100, G: 150, B: 200, A: 255})
+		}
+	}
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+	require.NoError(t, jpeg.Encode(file, img, nil))
+}
+
+// createBackupWithImage sets up a backup directory with metadata and optionally
+// an image file at the given relative path.
+func createBackupWithImage(t *testing.T, backupParentDir string, name string, createdAt time.Time, includesImages bool, relativeImagePath string, validImage bool) string {
+	t.Helper()
+	backupDir := filepath.Join(backupParentDir, name)
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	metadata := BackupMetadata{
+		Version:          currentVersion,
+		CreatedAt:        createdAt,
+		IncludesImages:   includesImages,
+		DatabaseFileName: databaseFileName,
+	}
+	require.NoError(t, writeMetadata(filepath.Join(backupDir, metadataFileName), metadata))
+
+	if relativeImagePath != "" && includesImages {
+		imagePath := filepath.Join(backupDir, imagesDirName, relativeImagePath)
+		if validImage {
+			createValidJPEG(t, imagePath)
+		} else {
+			// Create a corrupted image file
+			require.NoError(t, os.MkdirAll(filepath.Dir(imagePath), 0755))
+			require.NoError(t, os.WriteFile(imagePath, []byte("corrupted data"), 0644))
+		}
+	}
+
+	return backupDir
+}
+
+func TestRestoreSingleFile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("restore from newest backup", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/image.jpg"
+
+		// Create two backups: older with valid image, newer with valid image
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-02-01T10-00-00",
+			time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		require.NoError(t, err)
+		// Verify file was restored
+		restoredPath := filepath.Join(conf.ImageRootDirectory, relPath)
+		_, err = os.Stat(restoredPath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("fallback to older backup when newest is corrupted", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/image.jpg"
+
+		// Older backup has valid image
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+		// Newer backup has corrupted image
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-02-01T10-00-00",
+			time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), true, relPath, false)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		require.NoError(t, err)
+		// Verify file was restored from the older backup
+		restoredPath := filepath.Join(conf.ImageRootDirectory, relPath)
+		_, err = os.Stat(restoredPath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("skip backup without images", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/image.jpg"
+
+		// First backup does not include images
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-02-01T10-00-00",
+			time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), false, "", false)
+		// Second backup includes images with a valid copy
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		require.NoError(t, err)
+		restoredPath := filepath.Join(conf.ImageRootDirectory, relPath)
+		_, err = os.Stat(restoredPath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file not found in any backup", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/missing.jpg"
+
+		// Create a backup with images but not containing the requested file
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, "photos/other.jpg", true)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoValidBackup), "expected ErrNoValidBackup, got: %v", err)
+	})
+
+	t.Run("corrupted in all backups", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/image.jpg"
+
+		// Both backups have corrupted copies
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, false)
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-02-01T10-00-00",
+			time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC), true, relPath, false)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoValidBackup), "expected ErrNoValidBackup, got: %v", err)
+	})
+
+	t.Run("no backups exist", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		err := service.RestoreSingleFile(ctx, "photos/image.jpg", conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrNoValidBackup), "expected ErrNoValidBackup, got: %v", err)
+	})
+
+	t.Run("creates parent directories when restoring", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "deep/nested/dir/image.jpg"
+
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		require.NoError(t, err)
+		restoredPath := filepath.Join(conf.ImageRootDirectory, relPath)
+		_, err = os.Stat(restoredPath)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/backup/restore_test.go
+++ b/internal/backup/restore_test.go
@@ -177,6 +177,22 @@ func TestRestoreSingleFile(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrNoValidBackup), "expected ErrNoValidBackup, got: %v", err)
 	})
 
+	t.Run("ListBackups error returns error", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		// Replace the backup directory with a regular file so that
+		// ListBackups (which uses os.ReadDir) fails.
+		require.NoError(t, os.RemoveAll(conf.Backup.BackupDirectory))
+		require.NoError(t, os.WriteFile(conf.Backup.BackupDirectory, []byte("not a directory"), 0644))
+
+		service := NewRestoreService(logger, conf)
+
+		err := service.RestoreSingleFile(ctx, "photos/image.jpg", conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "list backups")
+	})
+
 	t.Run("creates parent directories when restoring", func(t *testing.T) {
 		conf := newTestConfig(t)
 		logger := newTestLogger()
@@ -193,5 +209,50 @@ func TestRestoreSingleFile(t *testing.T) {
 		restoredPath := filepath.Join(conf.ImageRootDirectory, relPath)
 		_, err = os.Stat(restoredPath)
 		assert.NoError(t, err)
+	})
+
+	t.Run("MkdirAll error when destination parent is a file", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/subdir/image.jpg"
+
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		// Create a regular file at the parent directory path to make MkdirAll fail
+		photosPath := filepath.Join(conf.ImageRootDirectory, "photos", "subdir")
+		require.NoError(t, os.MkdirAll(filepath.Join(conf.ImageRootDirectory, "photos"), 0755))
+		require.NoError(t, os.WriteFile(photosPath, []byte("blocking file"), 0644))
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "create parent directory")
+	})
+
+	t.Run("copyFile error when destination is read-only", func(t *testing.T) {
+		conf := newTestConfig(t)
+		logger := newTestLogger()
+		service := NewRestoreService(logger, conf)
+
+		relPath := "photos/image.jpg"
+
+		createBackupWithImage(t, conf.Backup.BackupDirectory, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		// Create the parent directory as read-only so the file cannot be created
+		destDir := filepath.Join(conf.ImageRootDirectory, "photos")
+		require.NoError(t, os.MkdirAll(destDir, 0755))
+		require.NoError(t, os.Chmod(destDir, 0555))
+		t.Cleanup(func() {
+			os.Chmod(destDir, 0755)
+		})
+
+		err := service.RestoreSingleFile(ctx, relPath, conf.ImageRootDirectory)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "copy restored file")
 	})
 }

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -222,24 +221,20 @@ func (client *FileClient) UpdateContentHash(id uint, hash string) error {
 }
 
 // BatchUpdateContentHashes updates the content_hash column for multiple file
-// records in a single SQL statement using a CASE expression. The updates map
-// is keyed by file ID.
+// records in a single transaction. The updates map is keyed by file ID.
 func (client *FileClient) BatchUpdateContentHashes(updates map[uint]string) error {
 	if len(updates) == 0 {
 		return nil
 	}
-
-	ids := make([]uint, 0, len(updates))
-	caseExpr := "CASE id"
-	for id, hash := range updates {
-		ids = append(ids, id)
-		caseExpr += fmt.Sprintf(" WHEN %d THEN '%s'", id, hash)
-	}
-	caseExpr += " END"
-
-	return client.connection.
-		Model(&File{}).
-		Where("id IN ?", ids).
-		Update("content_hash", gorm.Expr(caseExpr)).
-		Error
+	return client.connection.Transaction(func(tx *gorm.DB) error {
+		for id, hash := range updates {
+			if err := tx.Model(&File{}).
+				Where("id = ?", id).
+				Update("content_hash", hash).
+				Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -221,20 +222,24 @@ func (client *FileClient) UpdateContentHash(id uint, hash string) error {
 }
 
 // BatchUpdateContentHashes updates the content_hash column for multiple file
-// records in a single transaction. The updates map is keyed by file ID.
+// records in a single SQL statement using a CASE expression. The updates map
+// is keyed by file ID.
 func (client *FileClient) BatchUpdateContentHashes(updates map[uint]string) error {
 	if len(updates) == 0 {
 		return nil
 	}
-	return client.connection.Transaction(func(tx *gorm.DB) error {
-		for id, hash := range updates {
-			if err := tx.Model(&File{}).
-				Where("id = ?", id).
-				Update("content_hash", hash).
-				Error; err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+
+	ids := make([]uint, 0, len(updates))
+	caseExpr := "CASE id"
+	for id, hash := range updates {
+		ids = append(ids, id)
+		caseExpr += fmt.Sprintf(" WHEN %d THEN '%s'", id, hash)
+	}
+	caseExpr += " END"
+
+	return client.connection.
+		Model(&File{}).
+		Where("id IN ?", ids).
+		Update("content_hash", gorm.Expr(caseExpr)).
+		Error
 }

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -1,6 +1,10 @@
 package db
 
-import "context"
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
 
 type FileType string
 
@@ -214,4 +218,23 @@ func (client *FileClient) UpdateContentHash(id uint, hash string) error {
 		Where("id = ?", id).
 		Update("content_hash", hash).
 		Error
+}
+
+// BatchUpdateContentHashes updates the content_hash column for multiple file
+// records in a single transaction. The updates map is keyed by file ID.
+func (client *FileClient) BatchUpdateContentHashes(updates map[uint]string) error {
+	if len(updates) == 0 {
+		return nil
+	}
+	return client.connection.Transaction(func(tx *gorm.DB) error {
+		for id, hash := range updates {
+			if err := tx.Model(&File{}).
+				Where("id = ?", id).
+				Update("content_hash", hash).
+				Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -37,6 +37,10 @@ type File struct {
 	// EntryNumber is the season number or movie year. NULL when not applicable.
 	EntryNumber *uint `gorm:"column:entry_number"`
 
+	// ContentHash stores a hex-encoded SHA256 hash of the image file content.
+	// It is computed on import and used for fast corruption detection.
+	ContentHash string
+
 	// CreatedAt is a timestamp of the record creation
 	CreatedAt uint `gorm:"autoCreateTime,index:parent_id_created_at"`
 	UpdatedAt uint
@@ -190,5 +194,24 @@ func (client *FileClient) SetAnimeID(ctx context.Context, fileID uint, animeID *
 		Model(&File{}).
 		Where("id = ?", fileID).
 		Update("anime_id", animeID).
+		Error
+}
+
+// FindAllImageFiles returns all files of type image.
+func (client *FileClient) FindAllImageFiles() ([]File, error) {
+	var images []File
+	err := client.connection.
+		Where("type = ?", FileTypeImage).
+		Find(&images).
+		Error
+	return images, err
+}
+
+// UpdateContentHash sets the content_hash column for a single file record.
+func (client *FileClient) UpdateContentHash(id uint, hash string) error {
+	return client.connection.
+		Model(&File{}).
+		Where("id = ?", id).
+		Update("content_hash", hash).
 		Error
 }

--- a/internal/db/files_test.go
+++ b/internal/db/files_test.go
@@ -330,3 +330,81 @@ func TestFileClient_FindDirectoriesByIDs(t *testing.T) {
 		assert.Empty(t, got)
 	})
 }
+
+func TestFileClient_FindAllImageFiles(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, File{})
+
+	files := []File{
+		{ID: 5001, ParentID: 0, Name: "dir1", Type: FileTypeDirectory},
+		{ID: 5002, ParentID: 5001, Name: "img1.jpg", Type: FileTypeImage},
+		{ID: 5003, ParentID: 5001, Name: "img2.png", Type: FileTypeImage},
+		{ID: 5004, ParentID: 0, Name: "dir2", Type: FileTypeDirectory},
+	}
+	LoadTestData(t, testClient, files)
+
+	fileClient := testClient.File()
+
+	got, err := fileClient.FindAllImageFiles()
+	assert.NoError(t, err)
+	assert.Len(t, got, 2)
+
+	ids := []uint{got[0].ID, got[1].ID}
+	assert.Contains(t, ids, uint(5002))
+	assert.Contains(t, ids, uint(5003))
+}
+
+func TestFileClient_UpdateContentHash(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, File{})
+
+	files := []File{
+		{ID: 6001, ParentID: 0, Name: "dir1", Type: FileTypeDirectory},
+		{ID: 6002, ParentID: 6001, Name: "img1.jpg", Type: FileTypeImage},
+	}
+	LoadTestData(t, testClient, files)
+
+	fileClient := testClient.File()
+
+	t.Run("stores hash in database", func(t *testing.T) {
+		hash := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+		err := fileClient.UpdateContentHash(6002, hash)
+		assert.NoError(t, err)
+
+		// Verify the hash was stored
+		images, err := fileClient.FindAllImageFiles()
+		assert.NoError(t, err)
+		require.Len(t, images, 1)
+		assert.Equal(t, hash, images[0].ContentHash)
+	})
+
+	t.Run("updates existing hash", func(t *testing.T) {
+		newHash := "1111111111111111111111111111111111111111111111111111111111111111"
+		err := fileClient.UpdateContentHash(6002, newHash)
+		assert.NoError(t, err)
+
+		images, err := fileClient.FindAllImageFiles()
+		assert.NoError(t, err)
+		require.Len(t, images, 1)
+		assert.Equal(t, newHash, images[0].ContentHash)
+	})
+}
+
+func TestFileClient_ContentHashField(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, File{})
+
+	// Insert a file with a content hash
+	hash := "deadbeef" + "deadbeef" + "deadbeef" + "deadbeef" + "deadbeef" + "deadbeef" + "deadbeef" + "deadbeef"
+	files := []File{
+		{ID: 7001, ParentID: 0, Name: "dir1", Type: FileTypeDirectory},
+		{ID: 7002, ParentID: 7001, Name: "img.jpg", Type: FileTypeImage, ContentHash: hash},
+	}
+	LoadTestData(t, testClient, files)
+
+	// Verify the hash was persisted
+	got, err := testClient.File().FindAllImageFiles()
+	assert.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, hash, got[0].ContentHash)
+}

--- a/internal/db/files_test.go
+++ b/internal/db/files_test.go
@@ -390,6 +390,59 @@ func TestFileClient_UpdateContentHash(t *testing.T) {
 	})
 }
 
+func TestFileClient_BatchUpdateContentHashes(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, File{})
+
+	files := []File{
+		{ID: 8001, ParentID: 0, Name: "dir1", Type: FileTypeDirectory},
+		{ID: 8002, ParentID: 8001, Name: "img1.jpg", Type: FileTypeImage},
+		{ID: 8003, ParentID: 8001, Name: "img2.jpg", Type: FileTypeImage},
+		{ID: 8004, ParentID: 8001, Name: "img3.jpg", Type: FileTypeImage},
+	}
+	LoadTestData(t, testClient, files)
+
+	fileClient := testClient.File()
+
+	t.Run("updates multiple hashes in one call", func(t *testing.T) {
+		updates := map[uint]string{
+			8002: "aaaa",
+			8003: "bbbb",
+			8004: "cccc",
+		}
+		err := fileClient.BatchUpdateContentHashes(updates)
+		assert.NoError(t, err)
+
+		images, err := fileClient.FindAllImageFiles()
+		assert.NoError(t, err)
+		require.Len(t, images, 3)
+		hashByID := make(map[uint]string)
+		for _, img := range images {
+			hashByID[img.ID] = img.ContentHash
+		}
+		assert.Equal(t, "aaaa", hashByID[8002])
+		assert.Equal(t, "bbbb", hashByID[8003])
+		assert.Equal(t, "cccc", hashByID[8004])
+	})
+
+	t.Run("empty map is a no-op", func(t *testing.T) {
+		err := fileClient.BatchUpdateContentHashes(map[uint]string{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("single entry works", func(t *testing.T) {
+		err := fileClient.BatchUpdateContentHashes(map[uint]string{
+			8002: "dddd",
+		})
+		assert.NoError(t, err)
+
+		images, err := fileClient.FindImageFilesByIDs([]uint{8002})
+		assert.NoError(t, err)
+		require.Len(t, images, 1)
+		assert.Equal(t, "dddd", images[0].ContentHash)
+	})
+}
+
 func TestFileClient_ContentHashField(t *testing.T) {
 	testClient := NewTestClient(t)
 	testClient.Truncate(t, File{})

--- a/internal/frontend/file.go
+++ b/internal/frontend/file.go
@@ -10,53 +10,99 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/michael-freling/anime-image-viewer/internal/backup"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
 )
 
 type StaticFileService struct {
-	rootDirectory string
-	fileServer    http.Handler
-	logger        *slog.Logger
-	imageResizer  *image.Resizer
+	rootDirectory  string
+	fileServer     http.Handler
+	logger         *slog.Logger
+	imageResizer   *image.Resizer
+	restoreService *backup.RestoreService
 }
 
 func NewStaticFileService(
 	logger *slog.Logger,
 	conf config.Config,
+	restoreService *backup.RestoreService,
 ) *StaticFileService {
 	return &StaticFileService{
-		rootDirectory: conf.ImageRootDirectory,
-		fileServer:    http.FileServer(http.Dir(conf.ImageRootDirectory)),
-		logger:        logger,
-		imageResizer:  image.NewResizer(logger),
+		rootDirectory:  conf.ImageRootDirectory,
+		fileServer:     http.FileServer(http.Dir(conf.ImageRootDirectory)),
+		logger:         logger,
+		imageResizer:   image.NewResizer(logger),
+		restoreService: restoreService,
 	}
 }
 
 func (service StaticFileService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	localImageFilePath, width, err := service.validateRequest(r)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+		// If the file is not found, attempt restore before returning an error
+		if service.restoreService != nil && os.IsNotExist(err) {
+			relPath, relErr := filepath.Rel(service.rootDirectory, filepath.Join(service.rootDirectory, r.URL.Path))
+			if relErr == nil {
+				if restoreErr := service.tryRestore(r, relPath); restoreErr == nil {
+					// Re-validate after successful restore
+					localImageFilePath, width, err = service.validateRequest(r)
+				}
+			}
+		}
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 	}
+
+	ctx := r.Context()
+
 	if width == 0 {
+		// Full-size image: validate before serving
+		if err := image.ValidateImageFile(localImageFilePath); err != nil {
+			service.logger.WarnContext(ctx, "corrupted image detected",
+				"localImageFilePath", localImageFilePath,
+				"error", err,
+			)
+			if restoreErr := service.tryRestoreAndValidate(r, localImageFilePath); restoreErr != nil {
+				http.Error(w, fmt.Sprintf("image corrupted and restore failed: %v", restoreErr), http.StatusInternalServerError)
+				return
+			}
+		}
 		service.fileServer.ServeHTTP(w, r)
 		return
 	}
 
-	ctx := r.Context()
 	encoder, err := service.imageResizer.ResizeImage(
 		ctx,
 		localImageFilePath,
 		width,
 	)
 	if err != nil {
-		service.logger.ErrorContext(ctx, "ResizeImage",
+		// Attempt restore on decode errors
+		service.logger.WarnContext(ctx, "ResizeImage failed, attempting restore",
 			"localImageFilePath", localImageFilePath,
 			"error", err,
 		)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		if restoreErr := service.tryRestoreAndValidate(r, localImageFilePath); restoreErr != nil {
+			service.logger.ErrorContext(ctx, "restore failed after ResizeImage error",
+				"localImageFilePath", localImageFilePath,
+				"restoreError", restoreErr,
+			)
+			http.Error(w, fmt.Sprintf("image corrupted and restore failed: %v", restoreErr), http.StatusInternalServerError)
+			return
+		}
+		// Retry resize after successful restore
+		encoder, err = service.imageResizer.ResizeImage(ctx, localImageFilePath, width)
+		if err != nil {
+			service.logger.ErrorContext(ctx, "ResizeImage failed after restore",
+				"localImageFilePath", localImageFilePath,
+				"error", err,
+			)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 	bufWriter := bufio.NewWriter(w)
 	defer bufWriter.Flush()
@@ -70,6 +116,42 @@ func (service StaticFileService) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusOK)
 }
 
+// tryRestoreAndValidate computes the relative path of localImageFilePath and
+// attempts to restore it from backup.
+func (service StaticFileService) tryRestoreAndValidate(r *http.Request, localImageFilePath string) error {
+	if service.restoreService == nil {
+		return fmt.Errorf("no restore service configured")
+	}
+
+	relPath, err := filepath.Rel(service.rootDirectory, localImageFilePath)
+	if err != nil {
+		return fmt.Errorf("compute relative path: %w", err)
+	}
+
+	return service.tryRestore(r, relPath)
+}
+
+// tryRestore attempts to restore a single file from backup using its relative path.
+func (service StaticFileService) tryRestore(r *http.Request, relPath string) error {
+	if service.restoreService == nil {
+		return fmt.Errorf("no restore service configured")
+	}
+
+	ctx := r.Context()
+	service.logger.InfoContext(ctx, "attempting to restore file from backup",
+		"relativeFilePath", relPath,
+	)
+
+	if err := service.restoreService.RestoreSingleFile(ctx, relPath, service.rootDirectory); err != nil {
+		return fmt.Errorf("restore single file: %w", err)
+	}
+
+	service.logger.InfoContext(ctx, "file restored successfully from backup",
+		"relativeFilePath", relPath,
+	)
+	return nil
+}
+
 func (service StaticFileService) validateRequest(r *http.Request) (string, int, error) {
 	// check if a localImageFilePath is under the root directory
 	localImageFilePath := filepath.Join(service.rootDirectory, r.URL.Path)
@@ -77,7 +159,7 @@ func (service StaticFileService) validateRequest(r *http.Request) (string, int, 
 		return "", 0, fmt.Errorf("forbidden path: %s", r.URL.Path)
 	}
 	if _, err := os.Stat(localImageFilePath); err != nil {
-		return "", 0, fmt.Errorf("image was not found")
+		return "", 0, err
 	}
 
 	widthStr := r.URL.Query().Get("width")

--- a/internal/frontend/file_test.go
+++ b/internal/frontend/file_test.go
@@ -1,20 +1,30 @@
 package frontend
 
 import (
+	"encoding/json"
+	"image/color"
+	goimage "image"
+	"image/jpeg"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/michael-freling/anime-image-viewer/internal/backup"
+	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func (tester tester) getStaticFileService() *StaticFileService {
 	return NewStaticFileService(
 		tester.logger,
 		tester.config,
+		nil, // no restore service in basic tests
 	)
 }
 
@@ -103,4 +113,352 @@ func TestStaticFileService_ServeHTTP(t *testing.T) {
 			assert.Equal(t, tc.wantCode, w.Code, w.Body.String())
 		})
 	}
+}
+
+// createTestJPEG creates a valid JPEG image file at the given path.
+func createTestJPEG(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	img := goimage.NewRGBA(goimage.Rect(0, 0, 10, 10))
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, color.RGBA{R: 100, G: 150, B: 200, A: 255})
+		}
+	}
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	defer file.Close()
+	require.NoError(t, jpeg.Encode(file, img, nil))
+}
+
+// backupMetadata mirrors backup.BackupMetadata for creating test backup
+// directories from outside the backup package.
+type backupMetadata struct {
+	Version          int       `json:"version"`
+	CreatedAt        time.Time `json:"created_at"`
+	IncludesImages   bool      `json:"includes_images"`
+	ImageRootDir     string    `json:"image_root_directory"`
+	DatabaseFileName string    `json:"database_file_name"`
+}
+
+// createTestBackup creates a backup directory with metadata and optionally a
+// valid or corrupted image file at the given relative path. It returns the
+// backup directory path.
+func createTestBackup(
+	t *testing.T,
+	backupParentDir string,
+	name string,
+	createdAt time.Time,
+	includesImages bool,
+	relativeImagePath string,
+	validImage bool,
+) string {
+	t.Helper()
+	backupDir := filepath.Join(backupParentDir, name)
+	require.NoError(t, os.MkdirAll(backupDir, 0755))
+
+	meta := backupMetadata{
+		Version:          1,
+		CreatedAt:        createdAt,
+		IncludesImages:   includesImages,
+		ImageRootDir:     "",
+		DatabaseFileName: "database.sqlite",
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(backupDir, "metadata.json"), data, 0644))
+
+	if relativeImagePath != "" && includesImages {
+		imagePath := filepath.Join(backupDir, "images", relativeImagePath)
+		if validImage {
+			createTestJPEG(t, imagePath)
+		} else {
+			require.NoError(t, os.MkdirAll(filepath.Dir(imagePath), 0755))
+			require.NoError(t, os.WriteFile(imagePath, []byte("corrupted data"), 0644))
+		}
+	}
+
+	return backupDir
+}
+
+func TestStaticFileService_ServeHTTP_Restore(t *testing.T) {
+	t.Run("serve valid image without restore", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		// Create a valid image in the image directory
+		createTestJPEG(t, filepath.Join(imageDir, "photos", "good.jpg"))
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/photos/good.jpg", nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("serve corrupted full-size image restored from backup", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/corrupted.jpg"
+
+		// Create a corrupted image in the image directory
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("not a real image"), 0644))
+
+		// Create a backup with a valid copy
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("serve missing image restored from backup", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/missing.jpg"
+
+		// Do NOT create the image in the image directory (it is missing)
+
+		// Create a backup with a valid copy
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify the file was actually restored to disk
+		_, err := os.Stat(filepath.Join(imageDir, relPath))
+		assert.NoError(t, err, "restored file should exist on disk")
+	})
+
+	t.Run("corrupted image with no valid backup returns error", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/bad.jpg"
+
+		// Create a corrupted image in the image directory
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("not a real image"), 0644))
+
+		// Create a backup that also has a corrupted copy
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, false)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "image corrupted and restore failed")
+	})
+
+	t.Run("corrupted resized image restored from backup", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/resize_corrupt.jpg"
+
+		// Create a corrupted image in the image directory.
+		// When width is specified, ResizeImage is called. If the image is
+		// corrupted, the decode inside ResizeImage will fail and the service
+		// will attempt a restore.
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("not a real image"), 0644))
+
+		// Create a backup with a valid copy
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath+"?width=100", nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("restore called with correct relative path", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "deep/nested/dir/image.jpg"
+
+		// Create a corrupted image at a deeply nested path
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("corrupted"), 0644))
+
+		// Create a backup with a valid copy at the same relative path
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, true)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Verify the restored file is a valid image at the correct path
+		restoredPath := filepath.Join(imageDir, relPath)
+		err := image.ValidateImageFile(restoredPath)
+		assert.NoError(t, err, "restored file should be a valid image")
+	})
+
+	t.Run("missing image with no backups returns error", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/gone.jpg"
+
+		// No image on disk, no backups
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("nil restore service falls back to error on missing file", func(t *testing.T) {
+		imageDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+		}
+
+		// No restore service
+		service := NewStaticFileService(logger, conf, nil)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/photos/missing.jpg", nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }

--- a/internal/frontend/file_test.go
+++ b/internal/frontend/file_test.go
@@ -461,4 +461,71 @@ func TestStaticFileService_ServeHTTP_Restore(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
+
+	t.Run("nil restore service returns error for corrupted full-size image", func(t *testing.T) {
+		imageDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/corrupt_no_restore.jpg"
+
+		// Create a corrupted image on disk
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("not a real image"), 0644))
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+		}
+
+		// No restore service -- tryRestoreAndValidate will return "no restore service configured"
+		service := NewStaticFileService(logger, conf, nil)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath, nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "image corrupted and restore failed")
+	})
+
+	t.Run("corrupted resized image with no valid backup returns error", func(t *testing.T) {
+		imageDir := t.TempDir()
+		backupDir := t.TempDir()
+		logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+
+		relPath := "photos/resize_no_backup.jpg"
+
+		// Create a corrupted image on disk
+		corruptedPath := filepath.Join(imageDir, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(corruptedPath), 0755))
+		require.NoError(t, os.WriteFile(corruptedPath, []byte("not a real image"), 0644))
+
+		// Create a backup with a corrupted copy (no valid backup available)
+		createTestBackup(t, backupDir, "backup_2024-01-01T10-00-00",
+			time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC), true, relPath, false)
+
+		conf := config.Config{
+			ImageRootDirectory: imageDir,
+			ConfigDirectory:    t.TempDir(),
+			Environment:        "development",
+			Backup: config.BackupConfig{
+				BackupDirectory: backupDir,
+				RetentionCount:  7,
+			},
+		}
+
+		restoreService := backup.NewRestoreService(logger, conf)
+		service := NewStaticFileService(logger, conf, restoreService)
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/"+relPath+"?width=100", nil)
+		service.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		assert.Contains(t, w.Body.String(), "image corrupted and restore failed")
+	})
 }

--- a/internal/image/hash.go
+++ b/internal/image/hash.go
@@ -1,0 +1,26 @@
+package image
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+)
+
+// ComputeFileHash computes a SHA256 hash of the file at the given path and
+// returns the hex-encoded digest string.
+func ComputeFileHash(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open file for hashing: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("read file for hashing: %w", err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/image/hash_test.go
+++ b/internal/image/hash_test.go
@@ -1,0 +1,75 @@
+package image
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeFileHash(t *testing.T) {
+	t.Run("computes correct sha256 hash", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := []byte("hello world")
+		filePath := filepath.Join(tmpDir, "test.txt")
+		require.NoError(t, os.WriteFile(filePath, content, 0644))
+
+		hash, err := ComputeFileHash(filePath)
+
+		require.NoError(t, err)
+		expected := sha256.Sum256(content)
+		assert.Equal(t, hex.EncodeToString(expected[:]), hash)
+	})
+
+	t.Run("different content produces different hash", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		file1 := filepath.Join(tmpDir, "a.txt")
+		file2 := filepath.Join(tmpDir, "b.txt")
+		require.NoError(t, os.WriteFile(file1, []byte("content A"), 0644))
+		require.NoError(t, os.WriteFile(file2, []byte("content B"), 0644))
+
+		hash1, err := ComputeFileHash(file1)
+		require.NoError(t, err)
+		hash2, err := ComputeFileHash(file2)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("same content produces same hash", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		content := []byte("identical content")
+		file1 := filepath.Join(tmpDir, "a.txt")
+		file2 := filepath.Join(tmpDir, "b.txt")
+		require.NoError(t, os.WriteFile(file1, content, 0644))
+		require.NoError(t, os.WriteFile(file2, content, 0644))
+
+		hash1, err := ComputeFileHash(file1)
+		require.NoError(t, err)
+		hash2, err := ComputeFileHash(file2)
+		require.NoError(t, err)
+
+		assert.Equal(t, hash1, hash2)
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		_, err := ComputeFileHash("/nonexistent/file.txt")
+		assert.Error(t, err)
+	})
+
+	t.Run("empty file produces valid hash", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "empty.txt")
+		require.NoError(t, os.WriteFile(filePath, []byte{}, 0644))
+
+		hash, err := ComputeFileHash(filePath)
+
+		require.NoError(t, err)
+		expected := sha256.Sum256([]byte{})
+		assert.Equal(t, hex.EncodeToString(expected[:]), hash)
+	})
+}

--- a/internal/image/scanner.go
+++ b/internal/image/scanner.go
@@ -198,31 +198,39 @@ func isSQLiteBusyOrLocked(err error) bool {
 // retryBackoffs defines the sleep durations between retries for SQLite busy/locked errors.
 var retryBackoffs = []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
 
-// updateContentHashWithRetry attempts to store a content hash, retrying on SQLite
-// busy/locked errors with increasing backoff delays. The scanner runs in the
-// background so it can afford to wait.
-func (s *BackgroundScanner) updateContentHashWithRetry(ctx context.Context, imageID uint, hash string) error {
+// retryOnSQLiteBusy calls fn, retrying with increasing backoff when the error is
+// a SQLite BUSY or LOCKED error. It respects ctx cancellation between retries.
+func retryOnSQLiteBusy(ctx context.Context, logger *slog.Logger, label string, backoffs []time.Duration, fn func() error) error {
 	var err error
-	for attempt := 0; attempt <= len(retryBackoffs); attempt++ {
-		err = s.dbClient.File().UpdateContentHash(imageID, hash)
+	for attempt := 0; attempt <= len(backoffs); attempt++ {
+		err = fn()
 		if err == nil {
 			return nil
 		}
 		if !isSQLiteBusyOrLocked(err) {
 			return err
 		}
-		if attempt < len(retryBackoffs) {
-			s.logger.DebugContext(ctx, "background scan: SQLite busy, retrying",
-				"imageID", imageID, "attempt", attempt+1, "backoff", retryBackoffs[attempt],
+		if attempt < len(backoffs) {
+			logger.DebugContext(ctx, label+": SQLite busy, retrying",
+				"attempt", attempt+1, "backoff", backoffs[attempt],
 			)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			case <-time.After(retryBackoffs[attempt]):
+			case <-time.After(backoffs[attempt]):
 			}
 		}
 	}
 	return err
+}
+
+// updateContentHashWithRetry attempts to store a content hash, retrying on SQLite
+// busy/locked errors with increasing backoff delays. The scanner runs in the
+// background so it can afford to wait.
+func (s *BackgroundScanner) updateContentHashWithRetry(ctx context.Context, imageID uint, hash string) error {
+	return retryOnSQLiteBusy(ctx, s.logger, "background scan", retryBackoffs, func() error {
+		return s.dbClient.File().UpdateContentHash(imageID, hash)
+	})
 }
 
 // buildDirectoryMap flattens a Directory tree into a map keyed by directory ID.

--- a/internal/image/scanner.go
+++ b/internal/image/scanner.go
@@ -2,10 +2,13 @@ package image
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"time"
 
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 )
@@ -130,7 +133,7 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 				// Image is valid; compute and store the hash for future scans.
 				hash, hashErr := ComputeFileHash(absPath)
 				if hashErr == nil {
-					if dbErr := s.dbClient.File().UpdateContentHash(f.ID, hash); dbErr != nil {
+					if dbErr := s.updateContentHashWithRetry(ctx, f.ID, hash); dbErr != nil {
 						s.logger.WarnContext(ctx, "background scan: failed to store hash",
 							"imageID", f.ID, "error", dbErr,
 						)
@@ -154,7 +157,7 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 				// Recompute and store the hash after a successful restore.
 				hash, hashErr := ComputeFileHash(absPath)
 				if hashErr == nil {
-					if dbErr := s.dbClient.File().UpdateContentHash(f.ID, hash); dbErr != nil {
+					if dbErr := s.updateContentHashWithRetry(ctx, f.ID, hash); dbErr != nil {
 						s.logger.WarnContext(ctx, "background scan: failed to store hash after restore",
 							"imageID", f.ID, "error", dbErr,
 						)
@@ -164,11 +167,62 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 		}
 
 		scanned++
+
+		// Small sleep between images to reduce SQLite write contention with the
+		// rest of the application. The scanner runs in the background so
+		// throughput is not critical.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(50 * time.Millisecond):
+		}
 	}
 
 	s.logger.InfoContext(ctx, fmt.Sprintf("background scan complete: %d images scanned, %d corrupted, %d restored, %d failed",
 		scanned, corrupted, restored, failed),
 	)
+}
+
+// isSQLiteBusyOrLocked reports whether the error is a SQLite BUSY or LOCKED error.
+func isSQLiteBusyOrLocked(err error) bool {
+	if err == nil {
+		return false
+	}
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
+	}
+	return false
+}
+
+// retryBackoffs defines the sleep durations between retries for SQLite busy/locked errors.
+var retryBackoffs = []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
+
+// updateContentHashWithRetry attempts to store a content hash, retrying on SQLite
+// busy/locked errors with increasing backoff delays. The scanner runs in the
+// background so it can afford to wait.
+func (s *BackgroundScanner) updateContentHashWithRetry(ctx context.Context, imageID uint, hash string) error {
+	var err error
+	for attempt := 0; attempt <= len(retryBackoffs); attempt++ {
+		err = s.dbClient.File().UpdateContentHash(imageID, hash)
+		if err == nil {
+			return nil
+		}
+		if !isSQLiteBusyOrLocked(err) {
+			return err
+		}
+		if attempt < len(retryBackoffs) {
+			s.logger.DebugContext(ctx, "background scan: SQLite busy, retrying",
+				"imageID", imageID, "attempt", attempt+1, "backoff", retryBackoffs[attempt],
+			)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(retryBackoffs[attempt]):
+			}
+		}
+	}
+	return err
 }
 
 // buildDirectoryMap flattens a Directory tree into a map keyed by directory ID.

--- a/internal/image/scanner.go
+++ b/internal/image/scanner.go
@@ -1,0 +1,186 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/michael-freling/anime-image-viewer/internal/config"
+	"github.com/michael-freling/anime-image-viewer/internal/db"
+)
+
+// FileRestorer is an interface for restoring a single corrupted file from backups.
+// This is satisfied by backup.RestoreService.RestoreSingleFile.
+type FileRestorer interface {
+	RestoreSingleFile(ctx context.Context, relativeFilePath string, imageRootDir string) error
+}
+
+// BackgroundScanner scans all DB-tracked images on startup, validates them,
+// and attempts to restore corrupted files from backups.
+type BackgroundScanner struct {
+	logger   *slog.Logger
+	dbClient *db.Client
+	config   config.Config
+	restorer FileRestorer
+}
+
+// NewBackgroundScanner creates a new BackgroundScanner.
+func NewBackgroundScanner(
+	logger *slog.Logger,
+	dbClient *db.Client,
+	conf config.Config,
+	restorer FileRestorer,
+) *BackgroundScanner {
+	return &BackgroundScanner{
+		logger:   logger,
+		dbClient: dbClient,
+		config:   conf,
+		restorer: restorer,
+	}
+}
+
+// Start launches the background scan goroutine. It returns immediately and does
+// not block the caller. The scan respects ctx cancellation (e.g. on app shutdown).
+func (s *BackgroundScanner) Start(ctx context.Context) {
+	go s.run(ctx)
+}
+
+func (s *BackgroundScanner) run(ctx context.Context) {
+	s.logger.InfoContext(ctx, "background image scan started")
+
+	// Build a directory tree so we can resolve file paths.
+	directoryReader := NewDirectoryReader(s.config, s.dbClient)
+	dirTree, err := directoryReader.ReadDirectoryTree()
+	if err != nil {
+		s.logger.ErrorContext(ctx, "background scan: failed to read directory tree", "error", err)
+		return
+	}
+
+	// Collect all directories into a map keyed by ID for quick lookup.
+	dirMap := buildDirectoryMap(dirTree)
+
+	// Fetch every image file from the database.
+	imageFiles, err := s.dbClient.File().FindAllImageFiles()
+	if err != nil {
+		s.logger.ErrorContext(ctx, "background scan: failed to query image files", "error", err)
+		return
+	}
+
+	var scanned, corrupted, restored, failed int
+
+	for _, f := range imageFiles {
+		select {
+		case <-ctx.Done():
+			s.logger.WarnContext(ctx, "background scan cancelled",
+				"scanned", scanned, "corrupted", corrupted, "restored", restored, "failed", failed,
+			)
+			return
+		default:
+		}
+
+		parentDir, ok := dirMap[f.ParentID]
+		if !ok {
+			s.logger.WarnContext(ctx, "background scan: parent directory not found for image",
+				"imageID", f.ID, "parentID", f.ParentID,
+			)
+			failed++
+			scanned++
+			continue
+		}
+
+		absPath := filepath.Join(parentDir.Path, f.Name)
+		relPath, err := filepath.Rel(s.config.ImageRootDirectory, absPath)
+		if err != nil {
+			s.logger.ErrorContext(ctx, "background scan: failed to compute relative path",
+				"imageID", f.ID, "absPath", absPath, "error", err,
+			)
+			failed++
+			scanned++
+			continue
+		}
+
+		isCorrupted := false
+
+		// If the DB stores a content hash, do a fast hash comparison first.
+		if f.ContentHash != "" {
+			currentHash, hashErr := ComputeFileHash(absPath)
+			if hashErr != nil {
+				// File may be missing or unreadable — treat as corrupted.
+				s.logger.WarnContext(ctx, "background scan: cannot hash image file",
+					"imageID", f.ID, "path", absPath, "error", hashErr,
+				)
+				isCorrupted = true
+			} else if currentHash != f.ContentHash {
+				s.logger.WarnContext(ctx, "background scan: hash mismatch detected",
+					"imageID", f.ID, "path", absPath,
+					"expected", f.ContentHash, "actual", currentHash,
+				)
+				isCorrupted = true
+			}
+		} else {
+			// No stored hash — perform full image decode validation and backfill
+			// the hash if the image is valid.
+			if valErr := ValidateImageFile(absPath); valErr != nil {
+				s.logger.WarnContext(ctx, "background scan: image validation failed",
+					"imageID", f.ID, "path", absPath, "error", valErr,
+				)
+				isCorrupted = true
+			} else {
+				// Image is valid; compute and store the hash for future scans.
+				hash, hashErr := ComputeFileHash(absPath)
+				if hashErr == nil {
+					if dbErr := s.dbClient.File().UpdateContentHash(f.ID, hash); dbErr != nil {
+						s.logger.WarnContext(ctx, "background scan: failed to store hash",
+							"imageID", f.ID, "error", dbErr,
+						)
+					}
+				}
+			}
+		}
+
+		if isCorrupted {
+			corrupted++
+			if restoreErr := s.restorer.RestoreSingleFile(ctx, relPath, s.config.ImageRootDirectory); restoreErr != nil {
+				s.logger.ErrorContext(ctx, "background scan: restore failed",
+					"imageID", f.ID, "path", absPath, "error", restoreErr,
+				)
+				failed++
+			} else {
+				s.logger.InfoContext(ctx, "background scan: image restored from backup",
+					"imageID", f.ID, "path", absPath,
+				)
+				restored++
+				// Recompute and store the hash after a successful restore.
+				hash, hashErr := ComputeFileHash(absPath)
+				if hashErr == nil {
+					if dbErr := s.dbClient.File().UpdateContentHash(f.ID, hash); dbErr != nil {
+						s.logger.WarnContext(ctx, "background scan: failed to store hash after restore",
+							"imageID", f.ID, "error", dbErr,
+						)
+					}
+				}
+			}
+		}
+
+		scanned++
+	}
+
+	s.logger.InfoContext(ctx, fmt.Sprintf("background scan complete: %d images scanned, %d corrupted, %d restored, %d failed",
+		scanned, corrupted, restored, failed),
+	)
+}
+
+// buildDirectoryMap flattens a Directory tree into a map keyed by directory ID.
+func buildDirectoryMap(root Directory) map[uint]Directory {
+	m := make(map[uint]Directory)
+	var walk func(d Directory)
+	walk = func(d Directory) {
+		m[d.ID] = d
+		for _, child := range d.Children {
+			walk(*child)
+		}
+	}
+	walk(root)
+	return m
+}

--- a/internal/image/scanner.go
+++ b/internal/image/scanner.go
@@ -19,6 +19,10 @@ type FileRestorer interface {
 	RestoreSingleFile(ctx context.Context, relativeFilePath string, imageRootDir string) error
 }
 
+// hashBatchSize is the number of content-hash updates to accumulate before
+// flushing them to the database in a single transaction.
+const hashBatchSize = 100
+
 // BackgroundScanner scans all DB-tracked images on startup, validates them,
 // and attempts to restore corrupted files from backups.
 type BackgroundScanner struct {
@@ -71,6 +75,9 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 	}
 
 	var scanned, corrupted, restored, failed int
+
+	// Collect hash updates and flush them in batches to reduce DB round-trips.
+	pendingHashes := make(map[uint]string)
 
 	for _, f := range imageFiles {
 		select {
@@ -133,11 +140,7 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 				// Image is valid; compute and store the hash for future scans.
 				hash, hashErr := ComputeFileHash(absPath)
 				if hashErr == nil {
-					if dbErr := s.updateContentHashWithRetry(ctx, f.ID, hash); dbErr != nil {
-						s.logger.WarnContext(ctx, "background scan: failed to store hash",
-							"imageID", f.ID, "error", dbErr,
-						)
-					}
+					pendingHashes[f.ID] = hash
 				}
 			}
 		}
@@ -157,16 +160,22 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 				// Recompute and store the hash after a successful restore.
 				hash, hashErr := ComputeFileHash(absPath)
 				if hashErr == nil {
-					if dbErr := s.updateContentHashWithRetry(ctx, f.ID, hash); dbErr != nil {
-						s.logger.WarnContext(ctx, "background scan: failed to store hash after restore",
-							"imageID", f.ID, "error", dbErr,
-						)
-					}
+					pendingHashes[f.ID] = hash
 				}
 			}
 		}
 
 		scanned++
+
+		// Flush the batch when it reaches the threshold.
+		if len(pendingHashes) >= hashBatchSize {
+			if flushErr := s.flushHashBatchWithRetry(ctx, pendingHashes); flushErr != nil {
+				s.logger.WarnContext(ctx, "background scan: failed to flush hash batch",
+					"batchSize", len(pendingHashes), "error", flushErr,
+				)
+			}
+			pendingHashes = make(map[uint]string)
+		}
 
 		// Small sleep between images to reduce SQLite write contention with the
 		// rest of the application. The scanner runs in the background so
@@ -175,6 +184,15 @@ func (s *BackgroundScanner) run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Flush any remaining pending hashes.
+	if len(pendingHashes) > 0 {
+		if flushErr := s.flushHashBatchWithRetry(ctx, pendingHashes); flushErr != nil {
+			s.logger.WarnContext(ctx, "background scan: failed to flush final hash batch",
+				"batchSize", len(pendingHashes), "error", flushErr,
+			)
 		}
 	}
 
@@ -224,12 +242,11 @@ func retryOnSQLiteBusy(ctx context.Context, logger *slog.Logger, label string, b
 	return err
 }
 
-// updateContentHashWithRetry attempts to store a content hash, retrying on SQLite
-// busy/locked errors with increasing backoff delays. The scanner runs in the
-// background so it can afford to wait.
-func (s *BackgroundScanner) updateContentHashWithRetry(ctx context.Context, imageID uint, hash string) error {
-	return retryOnSQLiteBusy(ctx, s.logger, "background scan", retryBackoffs, func() error {
-		return s.dbClient.File().UpdateContentHash(imageID, hash)
+// flushHashBatchWithRetry writes a batch of content-hash updates in a single
+// transaction, retrying on SQLite busy/locked errors with increasing backoff.
+func (s *BackgroundScanner) flushHashBatchWithRetry(ctx context.Context, batch map[uint]string) error {
+	return retryOnSQLiteBusy(ctx, s.logger, "background scan batch", retryBackoffs, func() error {
+		return s.dbClient.File().BatchUpdateContentHashes(batch)
 	})
 }
 

--- a/internal/image/scanner_test.go
+++ b/internal/image/scanner_test.go
@@ -1,0 +1,260 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/michael-freling/anime-image-viewer/internal/config"
+	"github.com/michael-freling/anime-image-viewer/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createScannerTestJPEG creates a minimal valid JPEG at the given path.
+func createScannerTestJPEG(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
+	for y := 0; y < 10; y++ {
+		for x := 0; x < 10; x++ {
+			img.Set(x, y, color.RGBA{R: 100, G: 150, B: 200, A: 255})
+		}
+	}
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, jpeg.Encode(f, img, nil))
+}
+
+// mockRestorer is a test implementation of the FileRestorer interface.
+type mockRestorer struct {
+	mu    sync.Mutex
+	calls []mockRestorerCall
+	// restoreFn is called when RestoreSingleFile is invoked. If nil, an error
+	// is returned.
+	restoreFn func(ctx context.Context, relPath string, imageRootDir string) error
+}
+
+type mockRestorerCall struct {
+	RelPath      string
+	ImageRootDir string
+}
+
+func (m *mockRestorer) RestoreSingleFile(ctx context.Context, relativeFilePath string, imageRootDir string) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, mockRestorerCall{RelPath: relativeFilePath, ImageRootDir: imageRootDir})
+	m.mu.Unlock()
+	if m.restoreFn != nil {
+		return m.restoreFn(ctx, relativeFilePath, imageRootDir)
+	}
+	return errors.New("no backup available")
+}
+
+func TestBackgroundScanner_ScansValidImagesAndBackfillsHash(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	createScannerTestJPEG(t, filepath.Join(dirPath, "good.jpg"))
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "good.jpg", ParentID: 1, Type: db.FileTypeImage},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	files, err := dbClient.File().FindAllImageFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.NotEmpty(t, files[0].ContentHash, "content hash should be backfilled for valid images")
+	assert.Empty(t, restorer.calls)
+}
+
+func TestBackgroundScanner_DetectsCorruptedAndRestores(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	corruptedPath := filepath.Join(dirPath, "bad.jpg")
+	require.NoError(t, os.WriteFile(corruptedPath, []byte("not an image"), 0644))
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "bad.jpg", ParentID: 1, Type: db.FileTypeImage},
+	})
+
+	restorer := &mockRestorer{
+		restoreFn: func(ctx context.Context, relPath string, rootDir string) error {
+			destPath := filepath.Join(rootDir, relPath)
+			createScannerTestJPEG(t, destPath)
+			return nil
+		},
+	}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	require.Len(t, restorer.calls, 1)
+	assert.Equal(t, filepath.Join("photos", "bad.jpg"), restorer.calls[0].RelPath)
+
+	restoredPath := filepath.Join(dirPath, "bad.jpg")
+	assert.NoError(t, ValidateImageFile(restoredPath), "image should be restored")
+
+	files, err := dbClient.File().FindAllImageFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.NotEmpty(t, files[0].ContentHash, "content hash should be stored after restore")
+}
+
+func TestBackgroundScanner_DetectsHashMismatch(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	createScannerTestJPEG(t, filepath.Join(dirPath, "changed.jpg"))
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "changed.jpg", ParentID: 1, Type: db.FileTypeImage, ContentHash: "0000000000000000000000000000000000000000000000000000000000000000"},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	require.Len(t, restorer.calls, 1)
+	assert.Equal(t, filepath.Join("photos", "changed.jpg"), restorer.calls[0].RelPath)
+}
+
+func TestBackgroundScanner_HashMatchSkipsRestore(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	imgPath := filepath.Join(dirPath, "ok.jpg")
+	createScannerTestJPEG(t, imgPath)
+
+	hash, err := ComputeFileHash(imgPath)
+	require.NoError(t, err)
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "ok.jpg", ParentID: 1, Type: db.FileTypeImage, ContentHash: hash},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	files, err := dbClient.File().FindAllImageFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, hash, files[0].ContentHash)
+	assert.Empty(t, restorer.calls)
+}
+
+func TestBackgroundScanner_RespectsContextCancellation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+
+	dbFiles := []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+	}
+	for i := uint(2); i < 12; i++ {
+		name := "img_" + string(rune('a'+i)) + ".jpg"
+		createScannerTestJPEG(t, filepath.Join(dirPath, name))
+		dbFiles = append(dbFiles, db.File{
+			ID: i, Name: name, ParentID: 1, Type: db.FileTypeImage,
+		})
+	}
+	db.LoadTestData(t, dbClient, dbFiles)
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	scanner.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	// No assertion needed beyond "no panic/deadlock".
+}
+
+func TestBackgroundScanner_HandlesMissingParentDirectory(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "orphan.jpg", ParentID: 999, Type: db.FileTypeImage},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+	assert.Empty(t, restorer.calls)
+}

--- a/internal/image/scanner_test.go
+++ b/internal/image/scanner_test.go
@@ -537,26 +537,36 @@ func TestRetryOnSQLiteBusy_RespectsContextCancellation(t *testing.T) {
 	assert.Equal(t, 1, calls, "should stop retrying after context cancellation")
 }
 
-func TestUpdateContentHashWithRetry_SucceedsWithRealDB(t *testing.T) {
+func TestFlushHashBatchWithRetry_SucceedsWithRealDB(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	dbClient := db.NewTestClient(t)
 	dbClient.Truncate(t, db.File{})
 
 	db.LoadTestData(t, dbClient, []db.File{
 		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
-		{ID: 2, Name: "test.jpg", ParentID: 1, Type: db.FileTypeImage},
+		{ID: 2, Name: "test1.jpg", ParentID: 1, Type: db.FileTypeImage},
+		{ID: 3, Name: "test2.jpg", ParentID: 1, Type: db.FileTypeImage},
 	})
 
 	scanner := NewBackgroundScanner(logger, dbClient.Client, config.Config{}, &mockRestorer{})
 	ctx := context.Background()
 
-	err := scanner.updateContentHashWithRetry(ctx, 2, "abcdef1234567890")
+	batch := map[uint]string{
+		2: "abcdef1234567890",
+		3: "1234567890abcdef",
+	}
+	err := scanner.flushHashBatchWithRetry(ctx, batch)
 	require.NoError(t, err)
 
 	files, err := dbClient.File().FindAllImageFiles()
 	require.NoError(t, err)
-	require.Len(t, files, 1)
-	assert.Equal(t, "abcdef1234567890", files[0].ContentHash)
+	require.Len(t, files, 2)
+	hashByID := make(map[uint]string)
+	for _, f := range files {
+		hashByID[f.ID] = f.ContentHash
+	}
+	assert.Equal(t, "abcdef1234567890", hashByID[2])
+	assert.Equal(t, "1234567890abcdef", hashByID[3])
 }
 
 func TestRetryBackoffs_HasExpectedValues(t *testing.T) {

--- a/internal/image/scanner_test.go
+++ b/internal/image/scanner_test.go
@@ -237,6 +237,131 @@ func TestBackgroundScanner_RespectsContextCancellation(t *testing.T) {
 	// No assertion needed beyond "no panic/deadlock".
 }
 
+func TestBackgroundScanner_RestoreFailsStillContinues(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	// Create a corrupted image AND a valid image
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dirPath, "bad.jpg"), []byte("not an image"), 0644))
+	createScannerTestJPEG(t, filepath.Join(dirPath, "good.jpg"))
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "bad.jpg", ParentID: 1, Type: db.FileTypeImage},
+		{ID: 3, Name: "good.jpg", ParentID: 1, Type: db.FileTypeImage},
+	})
+
+	// Restorer always fails
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	// Should have attempted restore for the corrupted file
+	require.Len(t, restorer.calls, 1)
+
+	// The valid image should still get its hash backfilled
+	files, err := dbClient.File().FindAllImageFiles()
+	require.NoError(t, err)
+	hashFilled := 0
+	for _, f := range files {
+		if f.ContentHash != "" {
+			hashFilled++
+		}
+	}
+	assert.Equal(t, 1, hashFilled, "valid image should still have hash backfilled even when another image fails restore")
+}
+
+func TestBackgroundScanner_EmptyDB(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	// Should complete without errors when there are no images
+	scanner.run(ctx)
+	assert.Empty(t, restorer.calls)
+}
+
+func TestBackgroundScanner_MissingFileWithStoredHash(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	// Create directory on disk but NOT the image file
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+
+	// DB says the file has a hash, but the file doesn't exist on disk
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "missing.jpg", ParentID: 1, Type: db.FileTypeImage, ContentHash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	// Should have attempted restore because the file cannot be hashed
+	require.Len(t, restorer.calls, 1)
+	assert.Equal(t, filepath.Join("photos", "missing.jpg"), restorer.calls[0].RelPath)
+}
+
+func TestBackgroundScanner_MissingFileWithoutHash(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	imageRootDir := t.TempDir()
+	conf := config.Config{
+		ImageRootDirectory: imageRootDir,
+	}
+
+	// Create directory on disk but NOT the image file
+	dirPath := filepath.Join(imageRootDir, "photos")
+	require.NoError(t, os.MkdirAll(dirPath, 0755))
+
+	// DB has no hash and file doesn't exist on disk — triggers validation error
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "gone.jpg", ParentID: 1, Type: db.FileTypeImage},
+	})
+
+	restorer := &mockRestorer{}
+	scanner := NewBackgroundScanner(logger, dbClient.Client, conf, restorer)
+
+	ctx := context.Background()
+	scanner.run(ctx)
+
+	// Should have attempted restore because ValidateImageFile fails on missing file
+	require.Len(t, restorer.calls, 1)
+	assert.Equal(t, filepath.Join("photos", "gone.jpg"), restorer.calls[0].RelPath)
+}
+
 func TestBackgroundScanner_HandlesMissingParentDirectory(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	dbClient := db.NewTestClient(t)

--- a/internal/image/scanner_test.go
+++ b/internal/image/scanner_test.go
@@ -3,6 +3,7 @@ package image
 import (
 	"context"
 	"errors"
+	"fmt"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/stretchr/testify/assert"
@@ -382,4 +384,184 @@ func TestBackgroundScanner_HandlesMissingParentDirectory(t *testing.T) {
 	ctx := context.Background()
 	scanner.run(ctx)
 	assert.Empty(t, restorer.calls)
+}
+
+func TestIsSQLiteBusyOrLocked(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "non-sqlite error",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+		{
+			name: "sqlite busy error",
+			err: sqlite3.Error{
+				Code: sqlite3.ErrBusy,
+			},
+			expected: true,
+		},
+		{
+			name: "sqlite locked error",
+			err: sqlite3.Error{
+				Code: sqlite3.ErrLocked,
+			},
+			expected: true,
+		},
+		{
+			name: "wrapped sqlite busy error",
+			err: fmt.Errorf("db operation failed: %w", sqlite3.Error{
+				Code: sqlite3.ErrBusy,
+			}),
+			expected: true,
+		},
+		{
+			name: "wrapped sqlite locked error",
+			err: fmt.Errorf("db operation failed: %w", sqlite3.Error{
+				Code: sqlite3.ErrLocked,
+			}),
+			expected: true,
+		},
+		{
+			name: "other sqlite error code",
+			err: sqlite3.Error{
+				Code: sqlite3.ErrConstraint,
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isSQLiteBusyOrLocked(tt.err))
+		})
+	}
+}
+
+func TestRetryOnSQLiteBusy_SucceedsFirstTry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	err := retryOnSQLiteBusy(context.Background(), logger, "test", retryBackoffs, func() error {
+		calls++
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnSQLiteBusy_NonRetryableError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	permanentErr := fmt.Errorf("constraint violation")
+	err := retryOnSQLiteBusy(context.Background(), logger, "test", retryBackoffs, func() error {
+		calls++
+		return permanentErr
+	})
+	require.ErrorIs(t, err, permanentErr)
+	assert.Equal(t, 1, calls, "should not retry on non-SQLite-busy errors")
+}
+
+func TestRetryOnSQLiteBusy_RetriesOnBusyThenSucceeds(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	busyErr := sqlite3.Error{Code: sqlite3.ErrBusy}
+	// Use very short backoffs for the test.
+	shortBackoffs := []time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	err := retryOnSQLiteBusy(context.Background(), logger, "test", shortBackoffs, func() error {
+		calls++
+		if calls < 3 {
+			return busyErr
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls, "should succeed on third attempt")
+}
+
+func TestRetryOnSQLiteBusy_RetriesOnLockedThenSucceeds(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	lockedErr := sqlite3.Error{Code: sqlite3.ErrLocked}
+	shortBackoffs := []time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	err := retryOnSQLiteBusy(context.Background(), logger, "test", shortBackoffs, func() error {
+		calls++
+		if calls < 2 {
+			return lockedErr
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "should succeed on second attempt")
+}
+
+func TestRetryOnSQLiteBusy_ExhaustsRetries(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	busyErr := sqlite3.Error{Code: sqlite3.ErrBusy}
+	shortBackoffs := []time.Duration{1 * time.Millisecond, 1 * time.Millisecond, 1 * time.Millisecond}
+	err := retryOnSQLiteBusy(context.Background(), logger, "test", shortBackoffs, func() error {
+		calls++
+		return busyErr
+	})
+	require.Error(t, err)
+	// Initial attempt + 3 retries = 4 total calls
+	assert.Equal(t, 4, calls, "should attempt 1 initial + 3 retries")
+}
+
+func TestRetryOnSQLiteBusy_RespectsContextCancellation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	calls := 0
+	busyErr := sqlite3.Error{Code: sqlite3.ErrBusy}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Use longer backoffs so the cancel has time to take effect.
+	longBackoffs := []time.Duration{1 * time.Second, 1 * time.Second, 1 * time.Second}
+	go func() {
+		// Give the first attempt time to execute, then cancel.
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := retryOnSQLiteBusy(ctx, logger, "test", longBackoffs, func() error {
+		calls++
+		return busyErr
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "should stop retrying after context cancellation")
+}
+
+func TestUpdateContentHashWithRetry_SucceedsWithRealDB(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	dbClient := db.NewTestClient(t)
+	dbClient.Truncate(t, db.File{})
+
+	db.LoadTestData(t, dbClient, []db.File{
+		{ID: 1, Name: "photos", ParentID: 0, Type: db.FileTypeDirectory},
+		{ID: 2, Name: "test.jpg", ParentID: 1, Type: db.FileTypeImage},
+	})
+
+	scanner := NewBackgroundScanner(logger, dbClient.Client, config.Config{}, &mockRestorer{})
+	ctx := context.Background()
+
+	err := scanner.updateContentHashWithRetry(ctx, 2, "abcdef1234567890")
+	require.NoError(t, err)
+
+	files, err := dbClient.File().FindAllImageFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "abcdef1234567890", files[0].ContentHash)
+}
+
+func TestRetryBackoffs_HasExpectedValues(t *testing.T) {
+	require.Len(t, retryBackoffs, 3)
+	assert.Equal(t, 100*time.Millisecond, retryBackoffs[0])
+	assert.Equal(t, 500*time.Millisecond, retryBackoffs[1])
+	assert.Equal(t, 1*time.Second, retryBackoffs[2])
 }

--- a/internal/image/validator.go
+++ b/internal/image/validator.go
@@ -8,6 +8,7 @@ import (
 	_ "image/jpeg"
 	_ "image/png"
 	"os"
+	"strings"
 )
 
 var (
@@ -43,6 +44,14 @@ func ValidateImageFile(path string) error {
 
 	_, _, err = image.Decode(bufio.NewReader(file))
 	if err != nil {
+		// Go's image/png decoder strictly validates CRC checksums on every
+		// PNG chunk and rejects files with invalid CRCs. However, many image
+		// viewers (browsers, Windows Photo Viewer, etc.) display these files
+		// without issue. A common case is screen capture tools that write
+		// zeroed-out CRCs. Treat CRC-only failures as non-corrupted.
+		if strings.Contains(err.Error(), "invalid checksum") {
+			return nil
+		}
 		return fmt.Errorf("%w: %s: %v", ErrImageCorrupted, path, err)
 	}
 

--- a/internal/image/validator.go
+++ b/internal/image/validator.go
@@ -1,0 +1,50 @@
+package image
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"os"
+)
+
+var (
+	ErrImageCorrupted = errors.New("image file is corrupted")
+	ErrImageNotFound  = errors.New("image file not found")
+	ErrImageEmpty     = errors.New("image file is empty")
+)
+
+// ValidateImageFile opens the file at path and attempts a full image.Decode.
+// It returns nil when the file is a valid, decodable JPEG or PNG image.
+// Possible errors:
+//   - ErrImageNotFound: file does not exist on disk
+//   - ErrImageEmpty: file exists but has zero bytes
+//   - ErrImageCorrupted: file cannot be decoded as a valid image
+func ValidateImageFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: %s", ErrImageNotFound, path)
+		}
+		return fmt.Errorf("stat image file: %w", err)
+	}
+
+	if info.Size() == 0 {
+		return fmt.Errorf("%w: %s", ErrImageEmpty, path)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open image file: %w", err)
+	}
+	defer file.Close()
+
+	_, _, err = image.Decode(bufio.NewReader(file))
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrImageCorrupted, path, err)
+	}
+
+	return nil
+}

--- a/internal/image/validator_test.go
+++ b/internal/image/validator_test.go
@@ -71,6 +71,26 @@ func TestValidateImageFile(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrImageCorrupted), "expected ErrImageCorrupted, got: %v", err)
 	})
 
+	t.Run("stat error other than not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Create a directory with no execute permission so that stat on a
+		// file inside it returns a permission error, not a not-found error.
+		noExecDir := filepath.Join(tmpDir, "noperm")
+		require.NoError(t, os.MkdirAll(noExecDir, 0755))
+		filePath := filepath.Join(noExecDir, "image.jpg")
+		require.NoError(t, os.WriteFile(filePath, []byte("data"), 0644))
+		require.NoError(t, os.Chmod(noExecDir, 0000))
+		t.Cleanup(func() {
+			os.Chmod(noExecDir, 0755)
+		})
+
+		err := ValidateImageFile(filePath)
+
+		assert.Error(t, err)
+		assert.False(t, errors.Is(err, ErrImageNotFound), "should not be ErrImageNotFound")
+		assert.Contains(t, err.Error(), "stat image file")
+	})
+
 	t.Run("file with only jpeg header", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		filePath := filepath.Join(tmpDir, "header_only.jpg")

--- a/internal/image/validator_test.go
+++ b/internal/image/validator_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"encoding/binary"
 	"errors"
 	"os"
 	"path/filepath"
@@ -89,6 +90,48 @@ func TestValidateImageFile(t *testing.T) {
 		assert.Error(t, err)
 		assert.False(t, errors.Is(err, ErrImageNotFound), "should not be ErrImageNotFound")
 		assert.Contains(t, err.Error(), "stat image file")
+	})
+
+	t.Run("png with invalid CRC is not treated as corrupted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := createTestPNGFile(t, tmpDir, "bad_crc.png", 100, 100)
+
+		// Read the valid PNG, then zero out CRC bytes on a chunk to
+		// simulate the kind of file produced by some screen capture tools.
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+
+		// PNG structure: 8-byte signature, then chunks.
+		// Each chunk: 4-byte length (big-endian) | 4-byte type | <length> bytes data | 4-byte CRC.
+		// We skip the signature and walk chunks until we find IDAT, then
+		// zero out its CRC.
+		offset := 8 // skip PNG signature
+		crcZeroed := false
+		for offset+8 <= len(data) {
+			chunkLen := int(binary.BigEndian.Uint32(data[offset : offset+4]))
+			chunkType := string(data[offset+4 : offset+8])
+			crcStart := offset + 8 + chunkLen
+			if crcStart+4 > len(data) {
+				break
+			}
+			if chunkType == "IDAT" {
+				// Zero out the 4-byte CRC
+				data[crcStart] = 0
+				data[crcStart+1] = 0
+				data[crcStart+2] = 0
+				data[crcStart+3] = 0
+				crcZeroed = true
+				break
+			}
+			offset = crcStart + 4
+		}
+		require.True(t, crcZeroed, "failed to find and zero IDAT CRC in test PNG")
+		require.NoError(t, os.WriteFile(filePath, data, 0644))
+
+		// The image has a bad CRC but is otherwise structurally valid.
+		// ValidateImageFile should treat it as NOT corrupted.
+		err = ValidateImageFile(filePath)
+		assert.NoError(t, err)
 	})
 
 	t.Run("file with only jpeg header", func(t *testing.T) {

--- a/internal/image/validator_test.go
+++ b/internal/image/validator_test.go
@@ -1,0 +1,85 @@
+package image
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateImageFile(t *testing.T) {
+	t.Run("valid jpeg file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := createTestJPEGFile(t, tmpDir, "valid.jpg", 100, 100)
+
+		err := ValidateImageFile(filePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid png file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := createTestPNGFile(t, tmpDir, "valid.png", 100, 100)
+
+		err := ValidateImageFile(filePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		err := ValidateImageFile("/nonexistent/path/image.jpg")
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImageNotFound), "expected ErrImageNotFound, got: %v", err)
+	})
+
+	t.Run("zero-byte file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "empty.jpg")
+		require.NoError(t, os.WriteFile(filePath, []byte{}, 0644))
+
+		err := ValidateImageFile(filePath)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImageEmpty), "expected ErrImageEmpty, got: %v", err)
+	})
+
+	t.Run("corrupted file with invalid content", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "corrupted.jpg")
+		require.NoError(t, os.WriteFile(filePath, []byte("this is not an image"), 0644))
+
+		err := ValidateImageFile(filePath)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImageCorrupted), "expected ErrImageCorrupted, got: %v", err)
+	})
+
+	t.Run("truncated jpeg file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		// Create a valid JPEG, then truncate it
+		filePath := createTestJPEGFile(t, tmpDir, "truncated.jpg", 100, 100)
+		data, err := os.ReadFile(filePath)
+		require.NoError(t, err)
+		// Write only the first half of the file
+		require.NoError(t, os.WriteFile(filePath, data[:len(data)/2], 0644))
+
+		err = ValidateImageFile(filePath)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImageCorrupted), "expected ErrImageCorrupted, got: %v", err)
+	})
+
+	t.Run("file with only jpeg header", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "header_only.jpg")
+		// JPEG SOI marker followed by garbage
+		require.NoError(t, os.WriteFile(filePath, []byte{0xFF, 0xD8, 0xFF, 0x00}, 0644))
+
+		err := ValidateImageFile(filePath)
+
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImageCorrupted), "expected ErrImageCorrupted, got: %v", err)
+	})
+}

--- a/internal/import_images/batch_images.go
+++ b/internal/import_images/batch_images.go
@@ -46,6 +46,23 @@ func NewBatchImageImporter(
 	}
 }
 
+// storeContentHash computes and stores the SHA256 hash for a file. Errors are
+// logged but do not fail the import.
+func (batchImporter *BatchImageImporter) storeContentHash(fileID uint, filePath string) {
+	hash, err := image.ComputeFileHash(filePath)
+	if err != nil {
+		batchImporter.logger.Warn("failed to compute hash on import",
+			"path", filePath, "error", err,
+		)
+		return
+	}
+	if err := batchImporter.dbClient.File().UpdateContentHash(fileID, hash); err != nil {
+		batchImporter.logger.Warn("failed to store hash on import",
+			"path", filePath, "error", err,
+		)
+	}
+}
+
 func (batchImporter *BatchImageImporter) readImageFilePaths(
 	ctx context.Context,
 	paths []string,
@@ -191,18 +208,8 @@ func (batchImporter *BatchImageImporter) ImportImages(
 			}
 
 			// Compute and store the content hash for integrity tracking.
-			hash, hashErr := image.ComputeFileHash(destinationFilePath)
-			if hashErr != nil {
-				batchImporter.logger.Warn("failed to compute hash on import",
-					"path", destinationFilePath, "error", hashErr,
-				)
-			} else {
-				if dbErr := batchImporter.dbClient.File().UpdateContentHash(newImage.image.ID, hash); dbErr != nil {
-					batchImporter.logger.Warn("failed to store hash on import",
-						"path", destinationFilePath, "error", dbErr,
-					)
-				}
-			}
+			// Errors are logged but do not fail the import.
+			batchImporter.storeContentHash(newImage.image.ID, destinationFilePath)
 
 			resultImage, err := batchImporter.imageFileConverter.ConvertImageFile(destinationParentDirectory, newImage.image)
 			if err != nil {

--- a/internal/import_images/batch_images.go
+++ b/internal/import_images/batch_images.go
@@ -189,6 +189,21 @@ func (batchImporter *BatchImageImporter) ImportImages(
 				progressNotifier.addFailure(sourceFilePath, fmt.Errorf("image.copy: %w", err))
 				return nil
 			}
+
+			// Compute and store the content hash for integrity tracking.
+			hash, hashErr := image.ComputeFileHash(destinationFilePath)
+			if hashErr != nil {
+				batchImporter.logger.Warn("failed to compute hash on import",
+					"path", destinationFilePath, "error", hashErr,
+				)
+			} else {
+				if dbErr := batchImporter.dbClient.File().UpdateContentHash(newImage.image.ID, hash); dbErr != nil {
+					batchImporter.logger.Warn("failed to store hash on import",
+						"path", destinationFilePath, "error", dbErr,
+					)
+				}
+			}
+
 			resultImage, err := batchImporter.imageFileConverter.ConvertImageFile(destinationParentDirectory, newImage.image)
 			if err != nil {
 				progressNotifier.addFailure(sourceFilePath, fmt.Errorf("convertImageFile: %w", err))

--- a/internal/import_images/batch_images.go
+++ b/internal/import_images/batch_images.go
@@ -47,7 +47,7 @@ func NewBatchImageImporter(
 }
 
 // storeContentHash computes and stores the SHA256 hash for a file. Errors are
-// logged but do not fail the import.
+// logged but do not fail the import. Retries on SQLite busy/locked errors.
 func (batchImporter *BatchImageImporter) storeContentHash(fileID uint, filePath string) {
 	hash, err := image.ComputeFileHash(filePath)
 	if err != nil {
@@ -56,11 +56,20 @@ func (batchImporter *BatchImageImporter) storeContentHash(fileID uint, filePath 
 		)
 		return
 	}
-	if err := batchImporter.dbClient.File().UpdateContentHash(fileID, hash); err != nil {
-		batchImporter.logger.Warn("failed to store hash on import",
-			"path", filePath, "error", err,
-		)
+	backoffs := []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
+	var storeErr error
+	for attempt := 0; attempt <= len(backoffs); attempt++ {
+		storeErr = batchImporter.dbClient.File().UpdateContentHash(fileID, hash)
+		if storeErr == nil {
+			return
+		}
+		if attempt < len(backoffs) {
+			time.Sleep(backoffs[attempt])
+		}
 	}
+	batchImporter.logger.Warn("failed to store hash on import",
+		"path", filePath, "error", storeErr,
+	)
 }
 
 func (batchImporter *BatchImageImporter) readImageFilePaths(

--- a/internal/import_images/batch_images.go
+++ b/internal/import_images/batch_images.go
@@ -46,31 +46,6 @@ func NewBatchImageImporter(
 	}
 }
 
-// storeContentHash computes and stores the SHA256 hash for a file. Errors are
-// logged but do not fail the import. Retries on SQLite busy/locked errors.
-func (batchImporter *BatchImageImporter) storeContentHash(fileID uint, filePath string) {
-	hash, err := image.ComputeFileHash(filePath)
-	if err != nil {
-		batchImporter.logger.Warn("failed to compute hash on import",
-			"path", filePath, "error", err,
-		)
-		return
-	}
-	backoffs := []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second}
-	var storeErr error
-	for attempt := 0; attempt <= len(backoffs); attempt++ {
-		storeErr = batchImporter.dbClient.File().UpdateContentHash(fileID, hash)
-		if storeErr == nil {
-			return
-		}
-		if attempt < len(backoffs) {
-			time.Sleep(backoffs[attempt])
-		}
-	}
-	batchImporter.logger.Warn("failed to store hash on import",
-		"path", filePath, "error", storeErr,
-	)
-}
 
 func (batchImporter *BatchImageImporter) readImageFilePaths(
 	ctx context.Context,
@@ -177,6 +152,19 @@ func (batchImporter *BatchImageImporter) ImportImages(
 		return nil, errors.Join(progressNotifier.FailedErrors...)
 	}
 
+	// Compute content hashes from source files before inserting into DB.
+	// This avoids a separate UPDATE after the concurrent file copy.
+	for i, img := range newImportedImages {
+		hash, err := image.ComputeFileHash(img.sourceFilePath)
+		if err != nil {
+			batchImporter.logger.Warn("failed to compute hash on import",
+				"path", img.sourceFilePath, "error", err,
+			)
+			continue
+		}
+		newImportedImages[i].image.ContentHash = hash
+	}
+
 	if err := db.NewTransaction(ctx, batchImporter.dbClient, func(ctx context.Context) error {
 		files := make([]db.File, len(newImportedImages))
 		for index, newImage := range newImportedImages {
@@ -215,10 +203,6 @@ func (batchImporter *BatchImageImporter) ImportImages(
 				progressNotifier.addFailure(sourceFilePath, fmt.Errorf("image.copy: %w", err))
 				return nil
 			}
-
-			// Compute and store the content hash for integrity tracking.
-			// Errors are logged but do not fail the import.
-			batchImporter.storeContentHash(newImage.image.ID, destinationFilePath)
 
 			resultImage, err := batchImporter.imageFileConverter.ConvertImageFile(destinationParentDirectory, newImage.image)
 			if err != nil {

--- a/internal/import_images/batch_images_test.go
+++ b/internal/import_images/batch_images_test.go
@@ -270,3 +270,33 @@ func TestBatchImageImporter_importImageFiles(t *testing.T) {
 		assert.Equal(t, 1, progressNotifier.Failed, "should have 1 failed")
 	})
 }
+
+func TestBatchImageImporter_storeContentHash(t *testing.T) {
+	tester := newTester(t)
+	batchImporter := tester.getBatchImageImporter()
+
+	t.Run("nonexistent file logs warning without panic", func(t *testing.T) {
+		// Should not panic when file does not exist
+		batchImporter.storeContentHash(999, "/nonexistent/path/image.jpg")
+	})
+
+	t.Run("successful hash storage", func(t *testing.T) {
+		tester.dbClient.Truncate(t, db.File{})
+		db.LoadTestData(t, tester.dbClient, []db.File{
+			{ID: 1, ParentID: 0, Name: "dir", Type: db.FileTypeDirectory},
+			{ID: 2, ParentID: 1, Name: "test.jpg", Type: db.FileTypeImage},
+		})
+
+		// Create a real file to hash
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "test.jpg")
+		assert.NoError(t, os.WriteFile(filePath, []byte("image data"), 0644))
+
+		batchImporter.storeContentHash(2, filePath)
+
+		files, err := tester.dbClient.File().FindAllImageFiles()
+		assert.NoError(t, err)
+		assert.Len(t, files, 1)
+		assert.NotEmpty(t, files[0].ContentHash)
+	})
+}

--- a/internal/import_images/batch_images_test.go
+++ b/internal/import_images/batch_images_test.go
@@ -212,6 +212,11 @@ func TestBatchImageImporter_importImageFiles(t *testing.T) {
 			}
 
 			gotFiles := db.MustGetAll[db.File](t, dbClient)
+			// ContentHash is computed asynchronously on import; clear it for comparison
+			// since test expectations do not include hash values.
+			for i := range gotFiles {
+				gotFiles[i].ContentHash = ""
+			}
 			assert.Equal(t, tc.wantInsertFiles, gotFiles)
 			gotInsertedTags := db.MustGetAll[db.Tag](t, dbClient)
 			assert.Equal(t, tc.wantInsertTags, gotInsertedTags)

--- a/internal/import_images/batch_images_test.go
+++ b/internal/import_images/batch_images_test.go
@@ -271,32 +271,3 @@ func TestBatchImageImporter_importImageFiles(t *testing.T) {
 	})
 }
 
-func TestBatchImageImporter_storeContentHash(t *testing.T) {
-	tester := newTester(t)
-	batchImporter := tester.getBatchImageImporter()
-
-	t.Run("nonexistent file logs warning without panic", func(t *testing.T) {
-		// Should not panic when file does not exist
-		batchImporter.storeContentHash(999, "/nonexistent/path/image.jpg")
-	})
-
-	t.Run("successful hash storage", func(t *testing.T) {
-		tester.dbClient.Truncate(t, db.File{})
-		db.LoadTestData(t, tester.dbClient, []db.File{
-			{ID: 1, ParentID: 0, Name: "dir", Type: db.FileTypeDirectory},
-			{ID: 2, ParentID: 1, Name: "test.jpg", Type: db.FileTypeImage},
-		})
-
-		// Create a real file to hash
-		tmpDir := t.TempDir()
-		filePath := filepath.Join(tmpDir, "test.jpg")
-		assert.NoError(t, os.WriteFile(filePath, []byte("image data"), 0644))
-
-		batchImporter.storeContentHash(2, filePath)
-
-		files, err := tester.dbClient.File().FindAllImageFiles()
-		assert.NoError(t, err)
-		assert.Len(t, files, 1)
-		assert.NotEmpty(t, files[0].ContentHash)
-	})
-}

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"embed"
 	"fmt"
 	"io"
@@ -140,6 +141,13 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 	)
 
 	restoreService := backup.NewRestoreService(logger, conf)
+
+	// Start background image scanner — runs in a goroutine, non-blocking.
+	scanner := image.NewBackgroundScanner(logger, dbClient, conf, restoreService)
+	appCtx, appCancel := context.WithCancel(context.Background())
+	defer appCancel()
+	scanner.Start(appCtx)
+
 	backupFrontendService := frontend.NewBackupFrontendService(logger, conf)
 	configFrontendService := frontend.NewConfigFrontendService(logger, conf)
 
@@ -199,6 +207,7 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 			logger.Error("panic happens", "v", v)
 		},
 		OnShutdown: func() {
+			appCancel()
 			dbClient.Close()
 		},
 	})

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/michael-freling/anime-image-viewer/internal/anime"
+	"github.com/michael-freling/anime-image-viewer/internal/backup"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/frontend"
@@ -138,6 +139,7 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 		directoryReader,
 	)
 
+	restoreService := backup.NewRestoreService(logger, conf)
 	backupFrontendService := frontend.NewBackupFrontendService(logger, conf)
 	configFrontendService := frontend.NewConfigFrontendService(logger, conf)
 
@@ -166,7 +168,7 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 			application.NewService(tagService),
 			application.NewService(legacyTagFrontendService),
 			application.NewService(
-				frontend.NewStaticFileService(logger, conf),
+				frontend.NewStaticFileService(logger, conf, restoreService),
 				application.ServiceOptions{
 					Route: "/files/",
 				},


### PR DESCRIPTION
## Summary

- Add on-load image validation in the static file server that detects corrupted/missing images and transparently restores them from the newest valid backup before serving
- Introduce SHA256 content hash tracking — computed at import time and stored in the DB for fast corruption detection without full image decode
- Run a non-blocking background integrity scan on app startup that validates all images, restores corrupted ones from backups, and backfills hashes for existing images
- Validate images before backup creation and restore corrupted ones from older backups first, ensuring new backups only contain valid files
- Tolerate PNG files with invalid CRC checksums (common from screen capture tools) that browsers display fine but Go's strict decoder rejects
- Add SQLite retry with backoff for hash storage and batch updates in transactions to handle concurrent DB access