### PR TITLE
feat: AniList integration with BFS import, part grouping, and entry editing

### DIFF
--- a/frontend/src/pages/anime/AniListSearchModal.tsx
+++ b/frontend/src/pages/anime/AniListSearchModal.tsx
@@ -1,0 +1,215 @@
+import { Search } from "@mui/icons-material";
+import {
+  Box,
+  CircularProgress,
+  Input,
+  List,
+  ListDivider,
+  ListItem,
+  ListItemButton,
+  ListItemContent,
+  Modal,
+  ModalClose,
+  ModalDialog,
+  Stack,
+  Typography,
+} from "@mui/joy";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
+import {
+  AniListSearchResult,
+  AnimeService,
+} from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
+
+interface AniListSearchModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (result: AniListSearchResult) => void;
+  title?: string;
+}
+
+function formatSeason(season: string): string {
+  if (!season) return "";
+  return season.charAt(0).toUpperCase() + season.slice(1).toLowerCase();
+}
+
+const AniListSearchModal: FC<AniListSearchModalProps> = ({
+  open,
+  onClose,
+  onSelect,
+  title = "Search AniList",
+}) => {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<AniListSearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searched, setSearched] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setResults([]);
+      setLoading(false);
+      setError(null);
+      setSearched(false);
+    }
+  }, [open]);
+
+  const doSearch = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed === "") {
+      setResults([]);
+      setSearched(false);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await AnimeService.SearchAniList(trimmed);
+      setResults(res ?? []);
+      setSearched(true);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+      setResults([]);
+      setSearched(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+    }
+    timerRef.current = setTimeout(() => {
+      doSearch(value);
+    }, 300);
+  };
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const handleSelect = (result: AniListSearchResult) => {
+    onSelect(result);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <ModalDialog sx={{ minWidth: 520, maxHeight: "80vh" }}>
+        <ModalClose />
+        <Typography level="title-md">{title}</Typography>
+        <Stack spacing={2} sx={{ mt: 2 }}>
+          <Input
+            autoFocus
+            placeholder="Search anime on AniList..."
+            startDecorator={<Search />}
+            value={query}
+            onChange={(e) => handleQueryChange(e.target.value)}
+          />
+
+          {loading && (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+              <CircularProgress size="sm" />
+            </Box>
+          )}
+
+          {error && (
+            <Typography level="body-sm" color="danger">
+              {error}
+            </Typography>
+          )}
+
+          {!loading && !error && !searched && (
+            <Typography
+              level="body-sm"
+              sx={{ color: "text.secondary", textAlign: "center", py: 3 }}
+            >
+              Type to search AniList
+            </Typography>
+          )}
+
+          {!loading && !error && searched && results.length === 0 && (
+            <Typography
+              level="body-sm"
+              sx={{ color: "text.secondary", textAlign: "center", py: 3 }}
+            >
+              No results found
+            </Typography>
+          )}
+
+          {!loading && results.length > 0 && (
+            <List
+              variant="outlined"
+              sx={{
+                borderRadius: "sm",
+                maxHeight: 400,
+                overflow: "auto",
+              }}
+            >
+              {results.map((result, idx) => {
+                const displayTitle =
+                  result.titleEnglish || result.titleRomaji || "Unknown";
+                const seasonStr = formatSeason(result.season);
+                const subtitleParts: string[] = [];
+                if (result.format) subtitleParts.push(result.format);
+                if (seasonStr && result.seasonYear) {
+                  subtitleParts.push(`${seasonStr} ${result.seasonYear}`);
+                } else if (result.seasonYear) {
+                  subtitleParts.push(`${result.seasonYear}`);
+                }
+                if (result.episodes > 0) {
+                  subtitleParts.push(
+                    `${result.episodes} episode${result.episodes === 1 ? "" : "s"}`
+                  );
+                }
+
+                return (
+                  <Box key={result.id}>
+                    {idx > 0 && <ListDivider inset="gutter" />}
+                    <ListItem>
+                      <ListItemButton onClick={() => handleSelect(result)}>
+                        <ListItemContent>
+                          <Typography level="title-sm">
+                            {displayTitle}
+                          </Typography>
+                          {subtitleParts.length > 0 && (
+                            <Typography
+                              level="body-xs"
+                              sx={{ color: "text.secondary" }}
+                            >
+                              {subtitleParts.join(" \u00B7 ")}
+                            </Typography>
+                          )}
+                          {result.titleNative && (
+                            <Typography
+                              level="body-xs"
+                              sx={{ color: "text.tertiary" }}
+                            >
+                              {result.titleNative}
+                            </Typography>
+                          )}
+                        </ListItemContent>
+                      </ListItemButton>
+                    </ListItem>
+                  </Box>
+                );
+              })}
+            </List>
+          )}
+        </Stack>
+      </ModalDialog>
+    </Modal>
+  );
+};
+
+export default AniListSearchModal;

--- a/frontend/src/pages/anime/AnimeDetailPage.tsx
+++ b/frontend/src/pages/anime/AnimeDetailPage.tsx
@@ -93,38 +93,24 @@ const AnimeDetailPage: FC = () => {
   const [subEntryName, setSubEntryName] = useState("");
   const [subEntryError, setSubEntryError] = useState<string | null>(null);
 
-  // Rename entry modal state
-  const [renameEntryOpen, setRenameEntryOpen] = useState(false);
-  const [renameEntryId, setRenameEntryId] = useState(0);
-  const [renameEntryName, setRenameEntryName] = useState("");
-  const [renameEntryError, setRenameEntryError] = useState<string | null>(null);
+  // Edit entry modal state (consolidated: rename + airing info + set type)
+  const [editEntryOpen, setEditEntryOpen] = useState(false);
+  const [editEntryId, setEditEntryId] = useState(0);
+  const [editEntryName, setEditEntryName] = useState("");
+  const [editEntrySeason, setEditEntrySeason] = useState("");
+  const [editEntryYear, setEditEntryYear] = useState<number | null>(null);
+  const [editEntryType, setEditEntryType] = useState("");
+  const [editEntryDepth, setEditEntryDepth] = useState(0);
+  const [editEntryNewType, setEditEntryNewType] = useState<"season" | "movie" | "other">("season");
+  const [editEntrySeasonNumber, setEditEntrySeasonNumber] = useState(1);
+  const [editEntryMovieYear, setEditEntryMovieYear] = useState(new Date().getFullYear());
+  const [editEntryError, setEditEntryError] = useState<string | null>(null);
+  const [editEntrySubmitting, setEditEntrySubmitting] = useState(false);
 
   // Delete entry modal state
   const [deleteEntryOpen, setDeleteEntryOpen] = useState(false);
   const [deleteEntryId, setDeleteEntryId] = useState(0);
   const [deleteEntryName, setDeleteEntryName] = useState("");
-
-  // Set entry type modal state
-  const [setTypeOpen, setSetTypeOpen] = useState(false);
-  const [setTypeEntryId, setSetTypeEntryId] = useState(0);
-  const [setTypeEntryName, setSetTypeEntryName] = useState("");
-  const [setTypeType, setSetTypeType] = useState<"season" | "movie" | "other">(
-    "season"
-  );
-  const [setTypeSeasonNumber, setSetTypeSeasonNumber] = useState(1);
-  const [setTypeMovieYear, setSetTypeMovieYear] = useState(
-    new Date().getFullYear()
-  );
-  const [setTypeError, setSetTypeError] = useState<string | null>(null);
-  const [setTypeSubmitting, setSetTypeSubmitting] = useState(false);
-
-  // Edit airing info modal state
-  const [editAiringOpen, setEditAiringOpen] = useState(false);
-  const [editAiringEntryId, setEditAiringEntryId] = useState(0);
-  const [editAiringSeason, setEditAiringSeason] = useState("");
-  const [editAiringYear, setEditAiringYear] = useState<number | null>(null);
-  const [editAiringError, setEditAiringError] = useState<string | null>(null);
-  const [editAiringSubmitting, setEditAiringSubmitting] = useState(false);
 
   // Folder image panel state
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
@@ -392,21 +378,47 @@ const AnimeDetailPage: FC = () => {
     }
   };
 
-  // Rename entry handler
-  const handleRenameEntry = async () => {
-    const name = renameEntryName.trim();
+  // Edit entry handler (consolidated: rename + airing info + set type)
+  const handleEditEntry = async () => {
+    const name = editEntryName.trim();
     if (name === "") {
-      setRenameEntryError("Name is required");
+      setEditEntryError("Name is required");
       return;
     }
+    setEditEntrySubmitting(true);
+    setEditEntryError(null);
     try {
-      await AnimeService.RenameEntry(renameEntryId, name);
-      setRenameEntryOpen(false);
-      setRenameEntryError(null);
+      // Rename
+      await AnimeService.RenameEntry(editEntryId, name);
+      // Update airing info
+      await AnimeService.UpdateEntryAiringInfo(
+        editEntryId,
+        editEntrySeason,
+        editEntryYear ?? 0
+      );
+      // Set type if top-level and previously unset
+      if (editEntryDepth === 0 && editEntryType === "") {
+        let numberValue: number | null = null;
+        switch (editEntryNewType) {
+          case "season":
+            numberValue = editEntrySeasonNumber;
+            break;
+          case "movie":
+            numberValue = editEntryMovieYear;
+            break;
+          case "other":
+            numberValue = null;
+            break;
+        }
+        await AnimeService.UpdateEntryType(editEntryId, editEntryNewType, numberValue);
+      }
+      setEditEntryOpen(false);
       await load();
       await loadEntries();
     } catch (err: unknown) {
-      setRenameEntryError(err instanceof Error ? err.message : String(err));
+      setEditEntryError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEditEntrySubmitting(false);
     }
   };
 
@@ -425,54 +437,6 @@ const AnimeDetailPage: FC = () => {
       await loadEntries();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
-    }
-  };
-
-  // Set entry type handler
-  const handleSetEntryType = async () => {
-    setSetTypeSubmitting(true);
-    setSetTypeError(null);
-    try {
-      let numberValue: number | null = null;
-      switch (setTypeType) {
-        case "season":
-          numberValue = setTypeSeasonNumber;
-          break;
-        case "movie":
-          numberValue = setTypeMovieYear;
-          break;
-        case "other":
-          numberValue = null;
-          break;
-      }
-      await AnimeService.UpdateEntryType(setTypeEntryId, setTypeType, numberValue);
-      setSetTypeOpen(false);
-      await load();
-      await loadEntries();
-    } catch (err: unknown) {
-      setSetTypeError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSetTypeSubmitting(false);
-    }
-  };
-
-  // Edit airing info handler
-  const handleEditAiringInfo = async () => {
-    setEditAiringSubmitting(true);
-    setEditAiringError(null);
-    try {
-      await AnimeService.UpdateEntryAiringInfo(
-        editAiringEntryId,
-        editAiringSeason,
-        editAiringYear ?? 0
-      );
-      setEditAiringOpen(false);
-      await load();
-      await loadEntries();
-    } catch (err: unknown) {
-      setEditAiringError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setEditAiringSubmitting(false);
     }
   };
 
@@ -686,42 +650,130 @@ const AnimeDetailPage: FC = () => {
         nextSeasonNumber={nextSeasonNumber}
       />
 
-      {/* Rename entry modal */}
-      <Modal
-        open={renameEntryOpen}
-        onClose={() => setRenameEntryOpen(false)}
-      >
-        <ModalDialog sx={{ minWidth: 360 }}>
+      {/* Edit entry modal (rename + airing info + optional type) */}
+      <Modal open={editEntryOpen} onClose={() => setEditEntryOpen(false)}>
+        <ModalDialog sx={{ minWidth: 400 }}>
           <ModalClose />
-          <Typography level="title-md">Rename entry</Typography>
+          <Typography level="title-md">Edit Entry</Typography>
           <Stack spacing={2} sx={{ mt: 2 }}>
-            <Input
-              autoFocus
-              value={renameEntryName}
-              onChange={(e) => {
-                setRenameEntryName(e.target.value);
-                setRenameEntryError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleRenameEntry();
-                }
-              }}
-            />
-            {renameEntryError && (
+            <FormControl>
+              <FormLabel>Name</FormLabel>
+              <Input
+                autoFocus
+                value={editEntryName}
+                onChange={(e) => {
+                  setEditEntryName(e.target.value);
+                  setEditEntryError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleEditEntry();
+                  }
+                }}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Airing Season</FormLabel>
+              <Select
+                value={editEntrySeason}
+                onChange={(_e, value) => {
+                  setEditEntrySeason(value ?? "");
+                  setEditEntryError(null);
+                }}
+              >
+                <Option value="">(None)</Option>
+                <Option value="WINTER">Winter</Option>
+                <Option value="SPRING">Spring</Option>
+                <Option value="SUMMER">Summer</Option>
+                <Option value="FALL">Fall</Option>
+              </Select>
+            </FormControl>
+            <FormControl>
+              <FormLabel>Airing Year</FormLabel>
+              <Input
+                type="number"
+                value={editEntryYear ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setEditEntryYear(v === "" ? null : Number(v));
+                  setEditEntryError(null);
+                }}
+                slotProps={{ input: { min: 1900, max: 2100 } }}
+                placeholder="e.g. 2024"
+              />
+            </FormControl>
+
+            {/* Type selection: only for top-level entries with no type set */}
+            {editEntryDepth === 0 && editEntryType === "" && (
+              <>
+                <FormControl>
+                  <FormLabel>Type</FormLabel>
+                  <RadioGroup
+                    orientation="horizontal"
+                    value={editEntryNewType}
+                    onChange={(e) => {
+                      setEditEntryNewType(
+                        e.target.value as "season" | "movie" | "other"
+                      );
+                      setEditEntryError(null);
+                    }}
+                  >
+                    <Radio value="season" label="Season" />
+                    <Radio value="movie" label="Movie" />
+                    <Radio value="other" label="Other" />
+                  </RadioGroup>
+                </FormControl>
+
+                {editEntryNewType === "season" && (
+                  <FormControl>
+                    <FormLabel>Number</FormLabel>
+                    <Input
+                      type="number"
+                      value={editEntrySeasonNumber}
+                      onChange={(e) =>
+                        setEditEntrySeasonNumber(Number(e.target.value))
+                      }
+                      slotProps={{ input: { min: 1 } }}
+                    />
+                  </FormControl>
+                )}
+
+                {editEntryNewType === "movie" && (
+                  <FormControl>
+                    <FormLabel>Year</FormLabel>
+                    <Input
+                      type="number"
+                      value={editEntryMovieYear}
+                      onChange={(e) =>
+                        setEditEntryMovieYear(Number(e.target.value))
+                      }
+                      slotProps={{ input: { min: 1900, max: 2100 } }}
+                    />
+                  </FormControl>
+                )}
+              </>
+            )}
+
+            {editEntryError && (
               <Typography level="body-sm" color="danger">
-                {renameEntryError}
+                {editEntryError}
               </Typography>
             )}
             <Stack direction="row" spacing={1} justifyContent="flex-end">
               <Button
                 variant="plain"
                 color="neutral"
-                onClick={() => setRenameEntryOpen(false)}
+                onClick={() => setEditEntryOpen(false)}
               >
                 Cancel
               </Button>
-              <Button onClick={handleRenameEntry}>Save</Button>
+              <Button
+                disabled={editEntrySubmitting}
+                loading={editEntrySubmitting}
+                onClick={handleEditEntry}
+              >
+                Save
+              </Button>
             </Stack>
           </Stack>
         </ModalDialog>
@@ -754,147 +806,6 @@ const AnimeDetailPage: FC = () => {
             <Button color="danger" onClick={handleDeleteEntry}>
               Delete
             </Button>
-          </Stack>
-        </ModalDialog>
-      </Modal>
-
-      {/* Set entry type modal */}
-      <Modal open={setTypeOpen} onClose={() => setSetTypeOpen(false)}>
-        <ModalDialog sx={{ minWidth: 400 }}>
-          <ModalClose />
-          <Typography level="title-md">
-            Set Type for &quot;{setTypeEntryName}&quot;
-          </Typography>
-          <Stack spacing={2} sx={{ mt: 2 }}>
-            <FormControl>
-              <FormLabel>Type</FormLabel>
-              <RadioGroup
-                orientation="horizontal"
-                value={setTypeType}
-                onChange={(e) => {
-                  setSetTypeType(
-                    e.target.value as "season" | "movie" | "other"
-                  );
-                  setSetTypeError(null);
-                }}
-              >
-                <Radio value="season" label="Season" />
-                <Radio value="movie" label="Movie" />
-                <Radio value="other" label="Other" />
-              </RadioGroup>
-            </FormControl>
-
-            {setTypeType === "season" && (
-              <FormControl>
-                <FormLabel>Number</FormLabel>
-                <Input
-                  type="number"
-                  value={setTypeSeasonNumber}
-                  onChange={(e) =>
-                    setSetTypeSeasonNumber(Number(e.target.value))
-                  }
-                  slotProps={{ input: { min: 1 } }}
-                />
-              </FormControl>
-            )}
-
-            {setTypeType === "movie" && (
-              <FormControl>
-                <FormLabel>Year</FormLabel>
-                <Input
-                  type="number"
-                  value={setTypeMovieYear}
-                  onChange={(e) =>
-                    setSetTypeMovieYear(Number(e.target.value))
-                  }
-                  slotProps={{ input: { min: 1900, max: 2100 } }}
-                />
-              </FormControl>
-            )}
-
-            {setTypeError && (
-              <Typography level="body-sm" color="danger">
-                {setTypeError}
-              </Typography>
-            )}
-
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button
-                variant="plain"
-                color="neutral"
-                onClick={() => setSetTypeOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                disabled={setTypeSubmitting}
-                loading={setTypeSubmitting}
-                onClick={handleSetEntryType}
-              >
-                Save
-              </Button>
-            </Stack>
-          </Stack>
-        </ModalDialog>
-      </Modal>
-
-      {/* Edit airing info modal */}
-      <Modal open={editAiringOpen} onClose={() => setEditAiringOpen(false)}>
-        <ModalDialog sx={{ minWidth: 360 }}>
-          <ModalClose />
-          <Typography level="title-md">Edit Airing Info</Typography>
-          <Stack spacing={2} sx={{ mt: 2 }}>
-            <FormControl>
-              <FormLabel>Season</FormLabel>
-              <Select
-                value={editAiringSeason}
-                onChange={(_e, value) => {
-                  setEditAiringSeason(value ?? "");
-                  setEditAiringError(null);
-                }}
-              >
-                <Option value="">(None)</Option>
-                <Option value="WINTER">Winter</Option>
-                <Option value="SPRING">Spring</Option>
-                <Option value="SUMMER">Summer</Option>
-                <Option value="FALL">Fall</Option>
-              </Select>
-            </FormControl>
-            <FormControl>
-              <FormLabel>Year</FormLabel>
-              <Input
-                type="number"
-                value={editAiringYear ?? ""}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setEditAiringYear(v === "" ? null : Number(v));
-                  setEditAiringError(null);
-                }}
-                slotProps={{ input: { min: 1900, max: 2100 } }}
-                placeholder="e.g. 2024"
-              />
-            </FormControl>
-            {editAiringError && (
-              <Typography level="body-sm" color="danger">
-                {editAiringError}
-              </Typography>
-            )}
-            <Stack direction="row" spacing={1} justifyContent="flex-end">
-              <Button
-                variant="plain"
-                color="neutral"
-                onClick={() => setEditAiringOpen(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                disabled={editAiringSubmitting}
-                loading={editAiringSubmitting}
-                onClick={handleEditAiringInfo}
-              >
-                Save
-              </Button>
-            </Stack>
           </Stack>
         </ModalDialog>
       </Modal>
@@ -1048,34 +959,24 @@ const AnimeDetailPage: FC = () => {
             onAddEntry={() => setAddEntryOpen(true)}
             onAddSubEntry={handleAddSubEntry}
             onUploadImages={handleUploadImages}
-            onRenameEntry={(entryId, name) => {
-              setRenameEntryId(entryId);
-              setRenameEntryName(name);
-              setRenameEntryError(null);
-              setRenameEntryOpen(true);
+            onEditEntry={(entryId, currentName, currentSeason, currentYear, entryType, depth) => {
+              setEditEntryId(entryId);
+              setEditEntryName(currentName);
+              setEditEntrySeason(currentSeason);
+              setEditEntryYear(currentYear);
+              setEditEntryType(entryType);
+              setEditEntryDepth(depth);
+              setEditEntryNewType("season");
+              setEditEntrySeasonNumber(nextSeasonNumber);
+              setEditEntryMovieYear(new Date().getFullYear());
+              setEditEntryError(null);
+              setEditEntrySubmitting(false);
+              setEditEntryOpen(true);
             }}
             onDeleteEntry={(entryId, name) => {
               setDeleteEntryId(entryId);
               setDeleteEntryName(name);
               setDeleteEntryOpen(true);
-            }}
-            onSetEntryType={(entryId, name) => {
-              setSetTypeEntryId(entryId);
-              setSetTypeEntryName(name);
-              setSetTypeType("season");
-              setSetTypeSeasonNumber(nextSeasonNumber);
-              setSetTypeMovieYear(new Date().getFullYear());
-              setSetTypeError(null);
-              setSetTypeSubmitting(false);
-              setSetTypeOpen(true);
-            }}
-            onEditAiringInfo={(entryId, currentSeason, currentYear) => {
-              setEditAiringEntryId(entryId);
-              setEditAiringSeason(currentSeason);
-              setEditAiringYear(currentYear);
-              setEditAiringError(null);
-              setEditAiringSubmitting(false);
-              setEditAiringOpen(true);
             }}
           />
         </Box>

--- a/frontend/src/pages/anime/AnimeDetailPage.tsx
+++ b/frontend/src/pages/anime/AnimeDetailPage.tsx
@@ -31,6 +31,8 @@ import {
   Snackbar,
   Stack,
   Typography,
+  Option,
+  Select,
 } from "@mui/joy";
 import { FC, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router";
@@ -115,6 +117,14 @@ const AnimeDetailPage: FC = () => {
   );
   const [setTypeError, setSetTypeError] = useState<string | null>(null);
   const [setTypeSubmitting, setSetTypeSubmitting] = useState(false);
+
+  // Edit airing info modal state
+  const [editAiringOpen, setEditAiringOpen] = useState(false);
+  const [editAiringEntryId, setEditAiringEntryId] = useState(0);
+  const [editAiringSeason, setEditAiringSeason] = useState("");
+  const [editAiringYear, setEditAiringYear] = useState<number | null>(null);
+  const [editAiringError, setEditAiringError] = useState<string | null>(null);
+  const [editAiringSubmitting, setEditAiringSubmitting] = useState(false);
 
   // Folder image panel state
   const [selectedFolderId, setSelectedFolderId] = useState<number | null>(null);
@@ -446,6 +456,26 @@ const AnimeDetailPage: FC = () => {
     }
   };
 
+  // Edit airing info handler
+  const handleEditAiringInfo = async () => {
+    setEditAiringSubmitting(true);
+    setEditAiringError(null);
+    try {
+      await AnimeService.UpdateEntryAiringInfo(
+        editAiringEntryId,
+        editAiringSeason,
+        editAiringYear ?? 0
+      );
+      setEditAiringOpen(false);
+      await load();
+      await loadEntries();
+    } catch (err: unknown) {
+      setEditAiringError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setEditAiringSubmitting(false);
+    }
+  };
+
   // Convert tag category handler
   const handleConvertTagCategory = async (
     tagId: number,
@@ -509,7 +539,14 @@ const AnimeDetailPage: FC = () => {
         {details?.anime.name ?? "Anime"}
       </Typography>
       {details?.anime.aniListId != null && details.anime.aniListId > 0 && (
-        <Chip variant="soft" color="primary" size="sm" startDecorator={<LinkIcon sx={{ fontSize: 14 }} />}>
+        <Chip
+          variant="soft"
+          color="primary"
+          size="sm"
+          startDecorator={<LinkIcon sx={{ fontSize: 14 }} />}
+          onClick={() => window.open(`https://anilist.co/anime/${details.anime.aniListId}`, '_blank')}
+          sx={{ cursor: 'pointer' }}
+        >
           AniList
         </Chip>
       )}
@@ -801,6 +838,67 @@ const AnimeDetailPage: FC = () => {
         </ModalDialog>
       </Modal>
 
+      {/* Edit airing info modal */}
+      <Modal open={editAiringOpen} onClose={() => setEditAiringOpen(false)}>
+        <ModalDialog sx={{ minWidth: 360 }}>
+          <ModalClose />
+          <Typography level="title-md">Edit Airing Info</Typography>
+          <Stack spacing={2} sx={{ mt: 2 }}>
+            <FormControl>
+              <FormLabel>Season</FormLabel>
+              <Select
+                value={editAiringSeason}
+                onChange={(_e, value) => {
+                  setEditAiringSeason(value ?? "");
+                  setEditAiringError(null);
+                }}
+              >
+                <Option value="">(None)</Option>
+                <Option value="WINTER">Winter</Option>
+                <Option value="SPRING">Spring</Option>
+                <Option value="SUMMER">Summer</Option>
+                <Option value="FALL">Fall</Option>
+              </Select>
+            </FormControl>
+            <FormControl>
+              <FormLabel>Year</FormLabel>
+              <Input
+                type="number"
+                value={editAiringYear ?? ""}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setEditAiringYear(v === "" ? null : Number(v));
+                  setEditAiringError(null);
+                }}
+                slotProps={{ input: { min: 1900, max: 2100 } }}
+                placeholder="e.g. 2024"
+              />
+            </FormControl>
+            {editAiringError && (
+              <Typography level="body-sm" color="danger">
+                {editAiringError}
+              </Typography>
+            )}
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                variant="plain"
+                color="neutral"
+                onClick={() => setEditAiringOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                disabled={editAiringSubmitting}
+                loading={editAiringSubmitting}
+                onClick={handleEditAiringInfo}
+              >
+                Save
+              </Button>
+            </Stack>
+          </Stack>
+        </ModalDialog>
+      </Modal>
+
       {/* Add tag/character modal */}
       <Modal open={addTagOpen} onClose={() => setAddTagOpen(false)}>
         <ModalDialog sx={{ minWidth: 360 }}>
@@ -971,14 +1069,22 @@ const AnimeDetailPage: FC = () => {
               setSetTypeSubmitting(false);
               setSetTypeOpen(true);
             }}
+            onEditAiringInfo={(entryId, currentSeason, currentYear) => {
+              setEditAiringEntryId(entryId);
+              setEditAiringSeason(currentSeason);
+              setEditAiringYear(currentYear);
+              setEditAiringError(null);
+              setEditAiringSubmitting(false);
+              setEditAiringOpen(true);
+            }}
           />
         </Box>
 
         {/* Characters (tags where category === "character") */}
         {(() => {
-          const characterTags = details.tags.filter(
-            (t) => t.category === "character"
-          );
+          const characterTags = details.tags
+            .filter((t) => t.category === "character")
+            .sort((a, b) => b.imageCount - a.imageCount);
           return (
             <Box>
               <Stack

--- a/frontend/src/pages/anime/AnimeDetailPage.tsx
+++ b/frontend/src/pages/anime/AnimeDetailPage.tsx
@@ -3,6 +3,7 @@ import {
   ArrowBack,
   Delete,
   Edit,
+  Link as LinkIcon,
   LocalOffer,
   MoreVert,
   Person,
@@ -27,6 +28,7 @@ import {
   ModalDialog,
   Radio,
   RadioGroup,
+  Snackbar,
   Stack,
   Typography,
 } from "@mui/joy";
@@ -44,6 +46,7 @@ import ImageListMain from "../../components/Images/ImageList";
 import Layout from "../../Layout";
 import EntryList from "./EntryList";
 import AddEntryModal from "./AddEntryModal";
+import AniListSearchModal from "./AniListSearchModal";
 
 const AnimeDetailPage: FC = () => {
   const { animeId } = useParams<{ animeId: string }>();
@@ -121,6 +124,12 @@ const AnimeDetailPage: FC = () => {
   // Tag filtering state
   const [selectedTagIds, setSelectedTagIds] = useState<Set<number>>(new Set());
   const [imageTagMap, setImageTagMap] = useState<Record<number, number[]>>({});
+
+  // AniList linking state
+  const [aniListSearchOpen, setAniListSearchOpen] = useState(false);
+  const [aniListImporting, setAniListImporting] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
 
   const id = animeId != null ? Number(animeId) : NaN;
 
@@ -450,6 +459,24 @@ const AnimeDetailPage: FC = () => {
     }
   };
 
+  // AniList import handler
+  const handleAniListImport = async (aniListId: number) => {
+    setAniListImporting(true);
+    try {
+      const result = await AnimeService.ImportFromAniList(id, aniListId);
+      setSnackbarMessage(
+        `Imported ${result.entriesCreated} entries and ${result.charactersCreated} characters`
+      );
+      setSnackbarOpen(true);
+      await load();
+      await loadEntries();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setAniListImporting(false);
+    }
+  };
+
   const handleToggleTag = (tagId: number) => {
     setSelectedTagIds((prev) => {
       const next = new Set(prev);
@@ -481,6 +508,11 @@ const AnimeDetailPage: FC = () => {
       <Typography level="title-lg" sx={{ flex: 1 }}>
         {details?.anime.name ?? "Anime"}
       </Typography>
+      {details?.anime.aniListId != null && details.anime.aniListId > 0 && (
+        <Chip variant="soft" color="primary" size="sm" startDecorator={<LinkIcon sx={{ fontSize: 14 }} />}>
+          AniList
+        </Chip>
+      )}
       {details != null && (
         <>
           <Button
@@ -494,14 +526,37 @@ const AnimeDetailPage: FC = () => {
           >
             Rename
           </Button>
-          <Button
-            variant="outlined"
-            color="danger"
-            startDecorator={<Delete />}
-            onClick={handleDelete}
-          >
-            Delete
-          </Button>
+          <Dropdown>
+            <MenuButton
+              slots={{ root: IconButton }}
+              slotProps={{
+                root: {
+                  variant: "outlined",
+                  color: "neutral",
+                },
+              }}
+            >
+              <MoreVert />
+            </MenuButton>
+            <Menu size="sm" placement="bottom-end">
+              <MenuItem
+                disabled={aniListImporting}
+                onClick={() => setAniListSearchOpen(true)}
+              >
+                <ListItemDecorator>
+                  <LinkIcon fontSize="small" />
+                </ListItemDecorator>
+                Link AniList
+              </MenuItem>
+              <ListDivider />
+              <MenuItem color="danger" onClick={handleDelete}>
+                <ListItemDecorator>
+                  <Delete fontSize="small" />
+                </ListItemDecorator>
+                Delete
+              </MenuItem>
+            </Menu>
+          </Dropdown>
         </>
       )}
     </>
@@ -1238,6 +1293,27 @@ const AnimeDetailPage: FC = () => {
         />
       </Box>
       {modals}
+
+      {/* AniList search modal */}
+      <AniListSearchModal
+        open={aniListSearchOpen}
+        onClose={() => setAniListSearchOpen(false)}
+        onSelect={(result) => {
+          handleAniListImport(result.id);
+        }}
+        title="Link AniList"
+      />
+
+      {/* Import success snackbar */}
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={4000}
+        onClose={() => setSnackbarOpen(false)}
+        color="success"
+        variant="soft"
+      >
+        {snackbarMessage}
+      </Snackbar>
     </Layout.Main>
   );
 };

--- a/frontend/src/pages/anime/AnimeListPage.tsx
+++ b/frontend/src/pages/anime/AnimeListPage.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Checkbox,
   Chip,
+  CircularProgress,
   Input,
   List,
   ListDivider,
@@ -16,7 +17,7 @@ import {
   Stack,
   Typography,
 } from "@mui/joy";
-import { FC, useEffect, useState } from "react";
+import { FC, useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import {
   AniListSearchResult,
@@ -25,7 +26,11 @@ import {
   UnassignedFolder,
 } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
 import Layout from "../../Layout";
-import AniListSearchModal from "./AniListSearchModal";
+
+function formatSeason(season: string): string {
+  if (!season) return "";
+  return season.charAt(0).toUpperCase() + season.slice(1).toLowerCase();
+}
 
 const AnimeListPage: FC = () => {
   const [items, setItems] = useState<AnimeListItem[] | null>(null);
@@ -39,8 +44,11 @@ const AnimeListPage: FC = () => {
   const [importError, setImportError] = useState<string | null>(null);
   const [selectedFolderIds, setSelectedFolderIds] = useState<Set<number>>(new Set());
   const [importingBatch, setImportingBatch] = useState(false);
-  const [aniListSearchOpen, setAniListSearchOpen] = useState(false);
   const [selectedAniList, setSelectedAniList] = useState<AniListSearchResult | null>(null);
+  const [aniListResults, setAniListResults] = useState<AniListSearchResult[]>([]);
+  const [aniListLoading, setAniListLoading] = useState(false);
+  const [aniListSearched, setAniListSearched] = useState(false);
+  const aniListTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const navigate = useNavigate();
 
   const refresh = async () => {
@@ -56,6 +64,60 @@ const AnimeListPage: FC = () => {
   useEffect(() => {
     refresh();
   }, []);
+
+  // Cleanup AniList debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (aniListTimerRef.current != null) {
+        clearTimeout(aniListTimerRef.current);
+      }
+    };
+  }, []);
+
+  const doAniListSearch = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed === "") {
+      setAniListResults([]);
+      setAniListSearched(false);
+      setAniListLoading(false);
+      return;
+    }
+    setAniListLoading(true);
+    try {
+      const res = await AnimeService.SearchAniList(trimmed);
+      setAniListResults(res ?? []);
+      setAniListSearched(true);
+    } catch {
+      setAniListResults([]);
+      setAniListSearched(true);
+    } finally {
+      setAniListLoading(false);
+    }
+  }, []);
+
+  const handleNameChange = (value: string) => {
+    setNewName(value);
+    setCreateError(null);
+    setSelectedAniList(null);
+    setAniListResults([]);
+    setAniListSearched(false);
+    if (aniListTimerRef.current != null) {
+      clearTimeout(aniListTimerRef.current);
+    }
+    aniListTimerRef.current = setTimeout(() => {
+      doAniListSearch(value);
+    }, 300);
+  };
+
+  const handleAniListSelect = (result: AniListSearchResult) => {
+    setSelectedAniList(result);
+    const title = result.titleEnglish || result.titleRomaji;
+    if (title) {
+      setNewName(title);
+    }
+    setAniListResults([]);
+    setAniListSearched(false);
+  };
 
   const handleCreate = async () => {
     const name = newName.trim();
@@ -144,6 +206,9 @@ const AnimeListPage: FC = () => {
                 setCreateError(null);
                 setNewName("");
                 setSelectedAniList(null);
+                setAniListResults([]);
+                setAniListSearched(false);
+                setAniListLoading(false);
                 setCreateOpen(true);
               }}
             >
@@ -214,18 +279,16 @@ const AnimeListPage: FC = () => {
             <Input
               autoFocus
               placeholder="Anime name"
+              startDecorator={<Search />}
               value={newName}
-              onChange={(e) => {
-                setNewName(e.target.value);
-                setCreateError(null);
-              }}
+              onChange={(e) => handleNameChange(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !aniListLoading) {
                   handleCreate();
                 }
               }}
             />
-            {selectedAniList ? (
+            {selectedAniList && (
               <Chip
                 variant="soft"
                 color="primary"
@@ -238,17 +301,74 @@ const AnimeListPage: FC = () => {
               >
                 AniList linked: {selectedAniList.titleEnglish || selectedAniList.titleRomaji}
               </Chip>
-            ) : (
-              <Button
-                variant="plain"
-                color="neutral"
-                size="sm"
-                startDecorator={<Search />}
-                onClick={() => setAniListSearchOpen(true)}
-                sx={{ alignSelf: "flex-start" }}
+            )}
+            {aniListLoading && (
+              <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
+                <CircularProgress size="sm" />
+              </Box>
+            )}
+            {!selectedAniList && !aniListLoading && aniListSearched && aniListResults.length === 0 && (
+              <Typography
+                level="body-sm"
+                sx={{ color: "text.secondary", textAlign: "center", py: 1 }}
               >
-                Search AniList
-              </Button>
+                No AniList results found
+              </Typography>
+            )}
+            {!selectedAniList && !aniListLoading && aniListResults.length > 0 && (
+              <List
+                variant="outlined"
+                sx={{ borderRadius: "sm", maxHeight: 300, overflow: "auto" }}
+              >
+                {aniListResults.map((result, idx) => {
+                  const displayTitle =
+                    result.titleEnglish || result.titleRomaji || "Unknown";
+                  const seasonStr = formatSeason(result.season);
+                  const subtitleParts: string[] = [];
+                  if (result.format) subtitleParts.push(result.format);
+                  if (seasonStr && result.seasonYear) {
+                    subtitleParts.push(`${seasonStr} ${result.seasonYear}`);
+                  } else if (result.seasonYear) {
+                    subtitleParts.push(`${result.seasonYear}`);
+                  }
+                  if (result.episodes > 0) {
+                    subtitleParts.push(
+                      `${result.episodes} episode${result.episodes === 1 ? "" : "s"}`
+                    );
+                  }
+
+                  return (
+                    <Box key={result.id}>
+                      {idx > 0 && <ListDivider inset="gutter" />}
+                      <ListItem>
+                        <ListItemButton onClick={() => handleAniListSelect(result)}>
+                          <ListItemContent>
+                            <Typography level="title-sm">
+                              {displayTitle}
+                            </Typography>
+                            {subtitleParts.length > 0 && (
+                              <Typography
+                                level="body-xs"
+                                sx={{ color: "text.secondary" }}
+                              >
+                                {subtitleParts.join(" \u00B7 ")}
+                              </Typography>
+                            )}
+                            {result.titleNative && (
+                              <Typography
+                                level="body-xs"
+                                sx={{ color: "text.tertiary" }}
+                              >
+                                {result.titleNative}
+                              </Typography>
+                            )}
+                          </ListItemContent>
+                        </ListItemButton>
+                      </ListItem>
+                    </Box>
+                  );
+                })}
+              </List>
             )}
             {createError && (
               <Typography level="body-sm" color="danger">
@@ -268,19 +388,6 @@ const AnimeListPage: FC = () => {
           </Stack>
         </ModalDialog>
       </Modal>
-
-      {/* AniList search modal */}
-      <AniListSearchModal
-        open={aniListSearchOpen}
-        onClose={() => setAniListSearchOpen(false)}
-        onSelect={(result) => {
-          setSelectedAniList(result);
-          const title = result.titleEnglish || result.titleRomaji;
-          if (title && newName.trim() === "") {
-            setNewName(title);
-          }
-        }}
-      />
 
       {/* Import folders modal */}
       <Modal open={importOpen} onClose={() => setImportOpen(false)}>

--- a/frontend/src/pages/anime/AnimeListPage.tsx
+++ b/frontend/src/pages/anime/AnimeListPage.tsx
@@ -38,6 +38,7 @@ const AnimeListPage: FC = () => {
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [createError, setCreateError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [unassignedFolders, setUnassignedFolders] = useState<UnassignedFolder[]>([]);
   const [importLoading, setImportLoading] = useState(false);
@@ -125,6 +126,8 @@ const AnimeListPage: FC = () => {
       setCreateError("Name is required");
       return;
     }
+    setCreating(true);
+    setCreateError(null);
     try {
       const created = await AnimeService.CreateAnime(name);
       if (selectedAniList) {
@@ -137,6 +140,8 @@ const AnimeListPage: FC = () => {
       navigate(`/${created.id}`);
     } catch (err: unknown) {
       setCreateError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
     }
   };
 
@@ -271,19 +276,20 @@ const AnimeListPage: FC = () => {
       </Box>
 
       {/* Create anime modal */}
-      <Modal open={createOpen} onClose={() => setCreateOpen(false)}>
+      <Modal open={createOpen} onClose={() => { if (!creating) setCreateOpen(false); }}>
         <ModalDialog sx={{ minWidth: 360 }}>
-          <ModalClose />
+          {!creating && <ModalClose />}
           <Typography level="title-md">Create anime</Typography>
           <Stack spacing={2} sx={{ mt: 2 }}>
             <Input
               autoFocus
+              disabled={creating}
               placeholder="Anime name"
               startDecorator={<Search />}
               value={newName}
               onChange={(e) => handleNameChange(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && !aniListLoading) {
+                if (e.key === "Enter" && !aniListLoading && !creating) {
                   handleCreate();
                 }
               }}
@@ -379,11 +385,18 @@ const AnimeListPage: FC = () => {
               <Button
                 variant="plain"
                 color="neutral"
+                disabled={creating}
                 onClick={() => setCreateOpen(false)}
               >
                 Cancel
               </Button>
-              <Button onClick={handleCreate}>Create</Button>
+              <Button
+                disabled={creating}
+                loading={creating}
+                onClick={handleCreate}
+              >
+                Create
+              </Button>
             </Stack>
           </Stack>
         </ModalDialog>

--- a/frontend/src/pages/anime/AnimeListPage.tsx
+++ b/frontend/src/pages/anime/AnimeListPage.tsx
@@ -1,8 +1,9 @@
-import { Add, FileOpen } from "@mui/icons-material";
+import { Add, Close, FileOpen, Search } from "@mui/icons-material";
 import {
   Box,
   Button,
   Checkbox,
+  Chip,
   Input,
   List,
   ListDivider,
@@ -18,11 +19,13 @@ import {
 import { FC, useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 import {
+  AniListSearchResult,
   AnimeListItem,
   AnimeService,
   UnassignedFolder,
 } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
 import Layout from "../../Layout";
+import AniListSearchModal from "./AniListSearchModal";
 
 const AnimeListPage: FC = () => {
   const [items, setItems] = useState<AnimeListItem[] | null>(null);
@@ -36,6 +39,8 @@ const AnimeListPage: FC = () => {
   const [importError, setImportError] = useState<string | null>(null);
   const [selectedFolderIds, setSelectedFolderIds] = useState<Set<number>>(new Set());
   const [importingBatch, setImportingBatch] = useState(false);
+  const [aniListSearchOpen, setAniListSearchOpen] = useState(false);
+  const [selectedAniList, setSelectedAniList] = useState<AniListSearchResult | null>(null);
   const navigate = useNavigate();
 
   const refresh = async () => {
@@ -60,9 +65,13 @@ const AnimeListPage: FC = () => {
     }
     try {
       const created = await AnimeService.CreateAnime(name);
+      if (selectedAniList) {
+        await AnimeService.ImportFromAniList(created.id, selectedAniList.id);
+      }
       setCreateOpen(false);
       setNewName("");
       setCreateError(null);
+      setSelectedAniList(null);
       navigate(`/${created.id}`);
     } catch (err: unknown) {
       setCreateError(err instanceof Error ? err.message : String(err));
@@ -134,6 +143,7 @@ const AnimeListPage: FC = () => {
               onClick={() => {
                 setCreateError(null);
                 setNewName("");
+                setSelectedAniList(null);
                 setCreateOpen(true);
               }}
             >
@@ -215,6 +225,31 @@ const AnimeListPage: FC = () => {
                 }
               }}
             />
+            {selectedAniList ? (
+              <Chip
+                variant="soft"
+                color="primary"
+                endDecorator={
+                  <Close
+                    sx={{ fontSize: 16, cursor: "pointer" }}
+                    onClick={() => setSelectedAniList(null)}
+                  />
+                }
+              >
+                AniList linked: {selectedAniList.titleEnglish || selectedAniList.titleRomaji}
+              </Chip>
+            ) : (
+              <Button
+                variant="plain"
+                color="neutral"
+                size="sm"
+                startDecorator={<Search />}
+                onClick={() => setAniListSearchOpen(true)}
+                sx={{ alignSelf: "flex-start" }}
+              >
+                Search AniList
+              </Button>
+            )}
             {createError && (
               <Typography level="body-sm" color="danger">
                 {createError}
@@ -233,6 +268,19 @@ const AnimeListPage: FC = () => {
           </Stack>
         </ModalDialog>
       </Modal>
+
+      {/* AniList search modal */}
+      <AniListSearchModal
+        open={aniListSearchOpen}
+        onClose={() => setAniListSearchOpen(false)}
+        onSelect={(result) => {
+          setSelectedAniList(result);
+          const title = result.titleEnglish || result.titleRomaji;
+          if (title && newName.trim() === "") {
+            setNewName(title);
+          }
+        }}
+      />
 
       {/* Import folders modal */}
       <Modal open={importOpen} onClose={() => setImportOpen(false)}>

--- a/frontend/src/pages/anime/EntryList.tsx
+++ b/frontend/src/pages/anime/EntryList.tsx
@@ -1,10 +1,8 @@
 import {
   Add,
-  CalendarMonth,
   Delete,
   Edit,
   Folder as FolderIcon,
-  Label,
   Movie as MovieIcon,
   MoreVert,
   Tv,
@@ -33,10 +31,8 @@ interface EntryListProps {
   onAddEntry: () => void;
   onAddSubEntry: (parentId: number) => void;
   onUploadImages: (entryId: number) => void;
-  onRenameEntry: (entryId: number, currentName: string) => void;
+  onEditEntry: (entryId: number, currentName: string, currentSeason: string, currentYear: number | null, entryType: string, depth: number) => void;
   onDeleteEntry: (entryId: number, name: string) => void;
-  onSetEntryType: (entryId: number, currentName: string) => void;
-  onEditAiringInfo: (entryId: number, currentSeason: string, currentYear: number | null) => void;
 }
 
 function totalEntryImageCount(entry: AnimeEntryInfo): number {
@@ -130,10 +126,8 @@ const EntryNode: FC<{
   onSelectEntry: (entryId: number | null) => void;
   onAddSubEntry: (parentId: number) => void;
   onUploadImages: (entryId: number) => void;
-  onRenameEntry: (entryId: number, currentName: string) => void;
+  onEditEntry: (entryId: number, currentName: string, currentSeason: string, currentYear: number | null, entryType: string, depth: number) => void;
   onDeleteEntry: (entryId: number, name: string) => void;
-  onSetEntryType: (entryId: number, currentName: string) => void;
-  onEditAiringInfo: (entryId: number, currentSeason: string, currentYear: number | null) => void;
 }> = ({
   entry,
   depth,
@@ -141,10 +135,8 @@ const EntryNode: FC<{
   onSelectEntry,
   onAddSubEntry,
   onUploadImages,
-  onRenameEntry,
+  onEditEntry,
   onDeleteEntry,
-  onSetEntryType,
-  onEditAiringInfo,
 }) => {
   const isSelected = selectedEntryId === entry.id;
   const isFuture = isFutureEntry(entry);
@@ -320,31 +312,13 @@ const EntryNode: FC<{
               <MoreVert sx={{ fontSize: iconSize }} />
             </MenuButton>
             <Menu size="sm" placement="bottom-start">
-              {entry.entryType === "" && (
-                <MenuItem
-                  onClick={() => onSetEntryType(entry.id, entry.name)}
-                >
-                  <ListItemDecorator>
-                    <Label fontSize="small" />
-                  </ListItemDecorator>
-                  Set Type
-                </MenuItem>
-              )}
               <MenuItem
-                onClick={() => onEditAiringInfo(entry.id, entry.airingSeason, entry.airingYear)}
-              >
-                <ListItemDecorator>
-                  <CalendarMonth fontSize="small" />
-                </ListItemDecorator>
-                Edit Airing Info
-              </MenuItem>
-              <MenuItem
-                onClick={() => onRenameEntry(entry.id, entry.name)}
+                onClick={() => onEditEntry(entry.id, entry.name, entry.airingSeason, entry.airingYear, entry.entryType, depth)}
               >
                 <ListItemDecorator>
                   <Edit fontSize="small" />
                 </ListItemDecorator>
-                Rename
+                Edit
               </MenuItem>
               <ListDivider />
               <MenuItem
@@ -375,10 +349,8 @@ const EntryNode: FC<{
               onSelectEntry={onSelectEntry}
               onAddSubEntry={onAddSubEntry}
               onUploadImages={onUploadImages}
-              onRenameEntry={onRenameEntry}
+              onEditEntry={onEditEntry}
               onDeleteEntry={onDeleteEntry}
-              onSetEntryType={onSetEntryType}
-              onEditAiringInfo={onEditAiringInfo}
             />
           ))}
         </Box>
@@ -394,10 +366,8 @@ const EntryList: FC<EntryListProps> = ({
   onSelectEntry,
   onAddSubEntry,
   onUploadImages,
-  onRenameEntry,
+  onEditEntry,
   onDeleteEntry,
-  onSetEntryType,
-  onEditAiringInfo,
 }) => {
   return (
     <Box
@@ -448,10 +418,8 @@ const EntryList: FC<EntryListProps> = ({
               onSelectEntry={onSelectEntry}
               onAddSubEntry={onAddSubEntry}
               onUploadImages={onUploadImages}
-              onRenameEntry={onRenameEntry}
+              onEditEntry={onEditEntry}
               onDeleteEntry={onDeleteEntry}
-              onSetEntryType={onSetEntryType}
-              onEditAiringInfo={onEditAiringInfo}
             />
           ))}
         </Box>

--- a/frontend/src/pages/anime/EntryList.tsx
+++ b/frontend/src/pages/anime/EntryList.tsx
@@ -45,6 +45,14 @@ function totalEntryImageCount(entry: AnimeEntryInfo): number {
   return count;
 }
 
+function formatAiring(season: string, year: number | null | undefined): string {
+  const s = season ? season.charAt(0) + season.slice(1).toLowerCase() : "";
+  if (s && year) return `${s} ${year}`;
+  if (s) return s;
+  if (year) return `${year}`;
+  return "";
+}
+
 function entryBadge(type: string, number?: number): string {
   switch (type) {
     case "season":
@@ -209,7 +217,6 @@ const EntryNode: FC<{
         <Typography
           level={depth === 0 ? "body-sm" : "body-xs"}
           sx={{
-            flex: 1,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
@@ -217,6 +224,15 @@ const EntryNode: FC<{
         >
           {entry.name}
         </Typography>
+        {(entry.airingSeason || entry.airingYear) && (
+          <Typography
+            level="body-xs"
+            sx={{ color: "text.tertiary", ml: 0.5, flexShrink: 0 }}
+          >
+            {formatAiring(entry.airingSeason, entry.airingYear)}
+          </Typography>
+        )}
+        <Box sx={{ flex: 1 }} />
 
         {/* Image count (includes all descendant images) */}
         <Typography

--- a/frontend/src/pages/anime/EntryList.tsx
+++ b/frontend/src/pages/anime/EntryList.tsx
@@ -1,5 +1,6 @@
 import {
   Add,
+  CalendarMonth,
   Delete,
   Edit,
   Folder as FolderIcon,
@@ -35,6 +36,7 @@ interface EntryListProps {
   onRenameEntry: (entryId: number, currentName: string) => void;
   onDeleteEntry: (entryId: number, name: string) => void;
   onSetEntryType: (entryId: number, currentName: string) => void;
+  onEditAiringInfo: (entryId: number, currentSeason: string, currentYear: number | null) => void;
 }
 
 function totalEntryImageCount(entry: AnimeEntryInfo): number {
@@ -99,6 +101,26 @@ function entryIcon(type: string) {
   }
 }
 
+function isFutureEntry(entry: AnimeEntryInfo): boolean {
+  if (!entry.airingYear) return false;
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth() + 1; // 1-12
+
+  if (entry.airingYear > currentYear) return true;
+  if (entry.airingYear < currentYear) return false;
+
+  // Same year — check season
+  const seasonStartMonth: Record<string, number> = {
+    WINTER: 1,
+    SPRING: 4,
+    SUMMER: 7,
+    FALL: 10,
+  };
+  const startMonth = seasonStartMonth[entry.airingSeason] ?? 1;
+  return startMonth > currentMonth;
+}
+
 const MAX_ADD_DEPTH = 2; // can add sub-entries at depth 0, 1; not at 2+
 
 const EntryNode: FC<{
@@ -111,6 +133,7 @@ const EntryNode: FC<{
   onRenameEntry: (entryId: number, currentName: string) => void;
   onDeleteEntry: (entryId: number, name: string) => void;
   onSetEntryType: (entryId: number, currentName: string) => void;
+  onEditAiringInfo: (entryId: number, currentSeason: string, currentYear: number | null) => void;
 }> = ({
   entry,
   depth,
@@ -121,8 +144,10 @@ const EntryNode: FC<{
   onRenameEntry,
   onDeleteEntry,
   onSetEntryType,
+  onEditAiringInfo,
 }) => {
   const isSelected = selectedEntryId === entry.id;
+  const isFuture = isFutureEntry(entry);
   const hasChildren = entry.children && entry.children.length > 0;
   const badge =
     depth === 0
@@ -165,6 +190,7 @@ const EntryNode: FC<{
                 bgcolor: color,
                 flexShrink: 0,
                 mr: 1,
+                ...(isFuture && { opacity: 0.35 }),
               }}
             />
 
@@ -220,6 +246,7 @@ const EntryNode: FC<{
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
+            ...(isFuture && { opacity: 0.45, fontStyle: "italic" }),
           }}
         >
           {entry.name}
@@ -227,7 +254,7 @@ const EntryNode: FC<{
         {(entry.airingSeason || entry.airingYear) && (
           <Typography
             level="body-xs"
-            sx={{ color: "text.tertiary", ml: 0.5, flexShrink: 0 }}
+            sx={{ color: "text.tertiary", ml: 0.5, flexShrink: 0, ...(isFuture && { opacity: 0.45, fontStyle: "italic" }) }}
           >
             {formatAiring(entry.airingSeason, entry.airingYear)}
           </Typography>
@@ -304,6 +331,14 @@ const EntryNode: FC<{
                 </MenuItem>
               )}
               <MenuItem
+                onClick={() => onEditAiringInfo(entry.id, entry.airingSeason, entry.airingYear)}
+              >
+                <ListItemDecorator>
+                  <CalendarMonth fontSize="small" />
+                </ListItemDecorator>
+                Edit Airing Info
+              </MenuItem>
+              <MenuItem
                 onClick={() => onRenameEntry(entry.id, entry.name)}
               >
                 <ListItemDecorator>
@@ -343,6 +378,7 @@ const EntryNode: FC<{
               onRenameEntry={onRenameEntry}
               onDeleteEntry={onDeleteEntry}
               onSetEntryType={onSetEntryType}
+              onEditAiringInfo={onEditAiringInfo}
             />
           ))}
         </Box>
@@ -361,6 +397,7 @@ const EntryList: FC<EntryListProps> = ({
   onRenameEntry,
   onDeleteEntry,
   onSetEntryType,
+  onEditAiringInfo,
 }) => {
   return (
     <Box
@@ -414,6 +451,7 @@ const EntryList: FC<EntryListProps> = ({
               onRenameEntry={onRenameEntry}
               onDeleteEntry={onDeleteEntry}
               onSetEntryType={onSetEntryType}
+              onEditAiringInfo={onEditAiringInfo}
             />
           ))}
         </Box>

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.2
 require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/google/go-cmp v0.6.0
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/michael-freling/anime-image-viewer/plugins/plugins-protos/gen/go v0.0.0-00010101000000-000000000000
 	github.com/orandin/slog-gorm v1.4.0
 	github.com/spf13/cobra v1.8.1
@@ -47,7 +48,6 @@ require (
 	github.com/lmittmann/tint v1.0.4 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/internal/anilist/client.go
+++ b/internal/anilist/client.go
@@ -1,0 +1,276 @@
+package anilist
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const defaultEndpoint = "https://graphql.anilist.co"
+
+// Client is the interface for querying AniList. Using an interface allows
+// easy mocking in tests.
+type Client interface {
+	SearchAnime(ctx context.Context, query string, page int, perPage int) ([]MediaSearchResult, error)
+	GetAnimeDetail(ctx context.Context, id int) (*MediaDetail, error)
+}
+
+// HTTPClient is the production implementation that talks to AniList's GraphQL API.
+type HTTPClient struct {
+	endpoint   string
+	httpClient *http.Client
+}
+
+// NewHTTPClient creates a new AniList HTTP client.
+func NewHTTPClient() *HTTPClient {
+	return &HTTPClient{
+		endpoint:   defaultEndpoint,
+		httpClient: http.DefaultClient,
+	}
+}
+
+// NewHTTPClientWithEndpoint creates a client pointing at a custom endpoint (for testing).
+func NewHTTPClientWithEndpoint(endpoint string) *HTTPClient {
+	return &HTTPClient{
+		endpoint:   endpoint,
+		httpClient: http.DefaultClient,
+	}
+}
+
+const searchAnimeQuery = `query SearchAnime($search: String!, $page: Int, $perPage: Int) {
+  Page(page: $page, perPage: $perPage) {
+    media(search: $search, type: ANIME) {
+      id
+      title { romaji english native }
+      format
+      status
+      season
+      seasonYear
+      episodes
+      coverImage { large medium }
+    }
+  }
+}`
+
+const getAnimeDetailQuery = `query GetAnimeDetail($id: Int!) {
+  Media(id: $id, type: ANIME) {
+    id
+    title { romaji english native }
+    format
+    status
+    season
+    seasonYear
+    episodes
+    coverImage { large medium }
+    relations {
+      edges {
+        relationType(version: 2)
+        node {
+          id
+          title { romaji english native }
+          type
+          format
+          status
+          season
+          seasonYear
+          episodes
+        }
+      }
+    }
+    characters(sort: [ROLE, FAVOURITES_DESC], page: 1, perPage: 25) {
+      edges {
+        role
+        node {
+          id
+          name { full native }
+        }
+      }
+    }
+  }
+}`
+
+// graphqlRequest is the JSON body sent to the AniList GraphQL API.
+type graphqlRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+// searchResponse is the raw GraphQL response for a search query.
+type searchResponse struct {
+	Data struct {
+		Page struct {
+			Media []MediaSearchResult `json:"media"`
+		} `json:"Page"`
+	} `json:"data"`
+}
+
+// detailResponse is the raw GraphQL response for a detail query.
+type detailResponse struct {
+	Data struct {
+		Media *rawMediaDetail `json:"Media"`
+	} `json:"data"`
+}
+
+// rawMediaDetail mirrors the GraphQL response shape, which uses edges/node
+// for relations and characters.
+type rawMediaDetail struct {
+	ID         int        `json:"id"`
+	Title      MediaTitle `json:"title"`
+	Format     string     `json:"format"`
+	Status     string     `json:"status"`
+	Season     string     `json:"season"`
+	SeasonYear int        `json:"seasonYear"`
+	Episodes   int        `json:"episodes"`
+	CoverImage CoverImage `json:"coverImage"`
+	Relations  struct {
+		Edges []struct {
+			RelationType string `json:"relationType"`
+			Node         struct {
+				ID         int        `json:"id"`
+				Title      MediaTitle `json:"title"`
+				Type       string     `json:"type"`
+				Format     string     `json:"format"`
+				Status     string     `json:"status"`
+				Season     string     `json:"season"`
+				SeasonYear int        `json:"seasonYear"`
+				Episodes   int        `json:"episodes"`
+			} `json:"node"`
+		} `json:"edges"`
+	} `json:"relations"`
+	Characters struct {
+		Edges []struct {
+			Role string `json:"role"`
+			Node struct {
+				ID   int `json:"id"`
+				Name struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				} `json:"name"`
+			} `json:"node"`
+		} `json:"edges"`
+	} `json:"characters"`
+}
+
+// SearchAnime searches for anime by name. page is 1-indexed.
+func (c *HTTPClient) SearchAnime(ctx context.Context, query string, page int, perPage int) ([]MediaSearchResult, error) {
+	reqBody := graphqlRequest{
+		Query: searchAnimeQuery,
+		Variables: map[string]any{
+			"search":  query,
+			"page":    page,
+			"perPage": perPage,
+		},
+	}
+
+	body, err := c.doRequest(ctx, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp searchResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("anilist: failed to parse search response: %w", err)
+	}
+
+	return resp.Data.Page.Media, nil
+}
+
+// GetAnimeDetail fetches full details for a single anime by its AniList ID.
+func (c *HTTPClient) GetAnimeDetail(ctx context.Context, id int) (*MediaDetail, error) {
+	reqBody := graphqlRequest{
+		Query: getAnimeDetailQuery,
+		Variables: map[string]any{
+			"id": id,
+		},
+	}
+
+	body, err := c.doRequest(ctx, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp detailResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("anilist: failed to parse detail response: %w", err)
+	}
+
+	if resp.Data.Media == nil {
+		return nil, nil
+	}
+
+	return convertRawDetail(resp.Data.Media), nil
+}
+
+// doRequest sends the GraphQL request and returns the raw response body.
+func (c *HTTPClient) doRequest(ctx context.Context, reqBody graphqlRequest) ([]byte, error) {
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("anilist: failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("anilist: failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("anilist: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("anilist: failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("anilist: unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// convertRawDetail converts the raw GraphQL response into the flat MediaDetail type.
+func convertRawDetail(raw *rawMediaDetail) *MediaDetail {
+	detail := &MediaDetail{
+		ID:         raw.ID,
+		Title:      raw.Title,
+		Format:     raw.Format,
+		Status:     raw.Status,
+		Season:     raw.Season,
+		SeasonYear: raw.SeasonYear,
+		Episodes:   raw.Episodes,
+		CoverImage: raw.CoverImage,
+	}
+
+	for _, edge := range raw.Relations.Edges {
+		detail.Relations = append(detail.Relations, MediaRelation{
+			RelationType: edge.RelationType,
+			ID:           edge.Node.ID,
+			Title:        edge.Node.Title,
+			Type:         edge.Node.Type,
+			Format:       edge.Node.Format,
+			Status:       edge.Node.Status,
+			Season:       edge.Node.Season,
+			SeasonYear:   edge.Node.SeasonYear,
+			Episodes:     edge.Node.Episodes,
+		})
+	}
+
+	for _, edge := range raw.Characters.Edges {
+		ch := Character{
+			ID:   edge.Node.ID,
+			Role: edge.Role,
+		}
+		ch.Name.Full = edge.Node.Name.Full
+		ch.Name.Native = edge.Node.Name.Native
+		detail.Characters = append(detail.Characters, ch)
+	}
+
+	return detail
+}

--- a/internal/anilist/client.go
+++ b/internal/anilist/client.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
+	"time"
 )
 
 const defaultEndpoint = "https://graphql.anilist.co"
@@ -18,10 +20,16 @@ type Client interface {
 	GetAnimeDetail(ctx context.Context, id int) (*MediaDetail, error)
 }
 
+// minRequestGap is the minimum duration between consecutive HTTP requests to
+// AniList. 2 seconds keeps us well under the 30 req/min rate limit.
+const minRequestGap = 2 * time.Second
+
 // HTTPClient is the production implementation that talks to AniList's GraphQL API.
 type HTTPClient struct {
-	endpoint   string
-	httpClient *http.Client
+	endpoint    string
+	httpClient  *http.Client
+	mu          sync.Mutex
+	lastRequest time.Time
 }
 
 // NewHTTPClient creates a new AniList HTTP client.
@@ -205,7 +213,27 @@ func (c *HTTPClient) GetAnimeDetail(ctx context.Context, id int) (*MediaDetail, 
 }
 
 // doRequest sends the GraphQL request and returns the raw response body.
+// It enforces a minimum gap between consecutive requests to stay within
+// AniList's rate limit.
 func (c *HTTPClient) doRequest(ctx context.Context, reqBody graphqlRequest) ([]byte, error) {
+	// Throttle: ensure at least minRequestGap between requests.
+	c.mu.Lock()
+	if !c.lastRequest.IsZero() {
+		elapsed := time.Since(c.lastRequest)
+		if elapsed < minRequestGap {
+			wait := minRequestGap - elapsed
+			c.mu.Unlock()
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			c.mu.Lock()
+		}
+	}
+	c.lastRequest = time.Now()
+	c.mu.Unlock()
+
 	jsonBody, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("anilist: failed to marshal request: %w", err)
@@ -235,7 +263,7 @@ func (c *HTTPClient) doRequest(ctx context.Context, reqBody graphqlRequest) ([]b
 	return body, nil
 }
 
-// convertRawDetail converts the raw GraphQL response into the flat MediaDetail type.
+// convertRawDetail converts the raw GraphQL response into the MediaDetail type.
 func convertRawDetail(raw *rawMediaDetail) *MediaDetail {
 	detail := &MediaDetail{
 		ID:         raw.ID,

--- a/internal/anilist/client_test.go
+++ b/internal/anilist/client_test.go
@@ -319,3 +319,38 @@ func TestThrottle(t *testing.T) {
 	assert.Equal(t, int64(2), atomic.LoadInt64(&counter), "both requests should reach the server")
 	assert.GreaterOrEqual(t, elapsed, 2*time.Second, "throttle should enforce at least 2s gap between requests")
 }
+
+func TestNewHTTPClient(t *testing.T) {
+	client := NewHTTPClient()
+	assert.NotNil(t, client)
+	assert.Equal(t, defaultEndpoint, client.endpoint)
+	assert.NotNil(t, client.httpClient)
+}
+
+func TestGetAnimeDetail_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not valid json`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	detail, err := client.GetAnimeDetail(context.Background(), 1)
+	require.Error(t, err)
+	assert.Nil(t, detail)
+	assert.Contains(t, err.Error(), "failed to parse detail response")
+}
+
+func TestSearchAnime_InvalidJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`not valid json`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	results, err := client.SearchAnime(context.Background(), "test", 1, 10)
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "failed to parse search response")
+}

--- a/internal/anilist/client_test.go
+++ b/internal/anilist/client_test.go
@@ -1,0 +1,275 @@
+package anilist
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchAnime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var req graphqlRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "bocchi", req.Variables["search"])
+		assert.Equal(t, float64(1), req.Variables["page"])
+		assert.Equal(t, float64(10), req.Variables["perPage"])
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"Page": map[string]any{
+					"media": []map[string]any{
+						{
+							"id": 130003,
+							"title": map[string]any{
+								"romaji":  "Bocchi the Rock!",
+								"english": "Bocchi the Rock!",
+								"native":  "ぼっち・ざ・ろっく！",
+							},
+							"format":     "TV",
+							"status":     "FINISHED",
+							"season":     "FALL",
+							"seasonYear": 2022,
+							"episodes":   12,
+							"coverImage": map[string]any{
+								"large":  "https://example.com/large.jpg",
+								"medium": "https://example.com/medium.jpg",
+							},
+						},
+						{
+							"id": 999999,
+							"title": map[string]any{
+								"romaji":  "Bocchi the Rock! Movie",
+								"english": "Bocchi the Rock! Re:",
+								"native":  "劇場版ぼっち・ざ・ろっく！",
+							},
+							"format":     "MOVIE",
+							"status":     "NOT_YET_RELEASED",
+							"season":     "SUMMER",
+							"seasonYear": 2025,
+							"episodes":   1,
+							"coverImage": map[string]any{
+								"large":  "https://example.com/movie_large.jpg",
+								"medium": "https://example.com/movie_medium.jpg",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	results, err := client.SearchAnime(context.Background(), "bocchi", 1, 10)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// First result
+	assert.Equal(t, 130003, results[0].ID)
+	assert.Equal(t, "Bocchi the Rock!", results[0].Title.Romaji)
+	assert.Equal(t, "Bocchi the Rock!", results[0].Title.English)
+	assert.Equal(t, "ぼっち・ざ・ろっく！", results[0].Title.Native)
+	assert.Equal(t, "TV", results[0].Format)
+	assert.Equal(t, "FINISHED", results[0].Status)
+	assert.Equal(t, "FALL", results[0].Season)
+	assert.Equal(t, 2022, results[0].SeasonYear)
+	assert.Equal(t, 12, results[0].Episodes)
+	assert.Equal(t, "https://example.com/large.jpg", results[0].CoverImage.Large)
+	assert.Equal(t, "https://example.com/medium.jpg", results[0].CoverImage.Medium)
+
+	// Second result
+	assert.Equal(t, 999999, results[1].ID)
+	assert.Equal(t, "Bocchi the Rock! Movie", results[1].Title.Romaji)
+	assert.Equal(t, "MOVIE", results[1].Format)
+	assert.Equal(t, "NOT_YET_RELEASED", results[1].Status)
+	assert.Equal(t, "SUMMER", results[1].Season)
+	assert.Equal(t, 2025, results[1].SeasonYear)
+	assert.Equal(t, 1, results[1].Episodes)
+}
+
+func TestGetAnimeDetail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req graphqlRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, float64(130003), req.Variables["id"])
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"Media": map[string]any{
+					"id": 130003,
+					"title": map[string]any{
+						"romaji":  "Bocchi the Rock!",
+						"english": "Bocchi the Rock!",
+						"native":  "ぼっち・ざ・ろっく！",
+					},
+					"format":     "TV",
+					"status":     "FINISHED",
+					"season":     "FALL",
+					"seasonYear": 2022,
+					"episodes":   12,
+					"coverImage": map[string]any{
+						"large":  "https://example.com/large.jpg",
+						"medium": "https://example.com/medium.jpg",
+					},
+					"relations": map[string]any{
+						"edges": []map[string]any{
+							{
+								"relationType": "SEQUEL",
+								"node": map[string]any{
+									"id": 170010,
+									"title": map[string]any{
+										"romaji":  "Bocchi the Rock! 2nd Season",
+										"english": "Bocchi the Rock! Season 2",
+										"native":  "ぼっち・ざ・ろっく！ 2期",
+									},
+									"type":       "ANIME",
+									"format":     "TV",
+									"status":     "NOT_YET_RELEASED",
+									"season":     "WINTER",
+									"seasonYear": 2026,
+									"episodes":   12,
+								},
+							},
+							{
+								"relationType": "SIDE_STORY",
+								"node": map[string]any{
+									"id": 180050,
+									"title": map[string]any{
+										"romaji":  "Bocchi the Rock! OVA",
+										"english": "",
+										"native":  "ぼっち・ざ・ろっく！ OVA",
+									},
+									"type":       "ANIME",
+									"format":     "OVA",
+									"status":     "FINISHED",
+									"season":     "",
+									"seasonYear": 0,
+									"episodes":   1,
+								},
+							},
+						},
+					},
+					"characters": map[string]any{
+						"edges": []map[string]any{
+							{
+								"role": "MAIN",
+								"node": map[string]any{
+									"id": 200001,
+									"name": map[string]any{
+										"full":   "Hitori Gotou",
+										"native": "後藤 ひとり",
+									},
+								},
+							},
+							{
+								"role": "SUPPORTING",
+								"node": map[string]any{
+									"id": 200002,
+									"name": map[string]any{
+										"full":   "Nijika Ijichi",
+										"native": "伊地知 虹夏",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	detail, err := client.GetAnimeDetail(context.Background(), 130003)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	// Verify base fields
+	assert.Equal(t, 130003, detail.ID)
+	assert.Equal(t, "Bocchi the Rock!", detail.Title.Romaji)
+	assert.Equal(t, "TV", detail.Format)
+	assert.Equal(t, "FINISHED", detail.Status)
+	assert.Equal(t, "FALL", detail.Season)
+	assert.Equal(t, 2022, detail.SeasonYear)
+	assert.Equal(t, 12, detail.Episodes)
+	assert.Equal(t, "https://example.com/large.jpg", detail.CoverImage.Large)
+
+	// Verify relations
+	require.Len(t, detail.Relations, 2)
+
+	assert.Equal(t, "SEQUEL", detail.Relations[0].RelationType)
+	assert.Equal(t, 170010, detail.Relations[0].ID)
+	assert.Equal(t, "Bocchi the Rock! 2nd Season", detail.Relations[0].Title.Romaji)
+	assert.Equal(t, "ANIME", detail.Relations[0].Type)
+	assert.Equal(t, "TV", detail.Relations[0].Format)
+	assert.Equal(t, "NOT_YET_RELEASED", detail.Relations[0].Status)
+	assert.Equal(t, "WINTER", detail.Relations[0].Season)
+	assert.Equal(t, 2026, detail.Relations[0].SeasonYear)
+	assert.Equal(t, 12, detail.Relations[0].Episodes)
+
+	assert.Equal(t, "SIDE_STORY", detail.Relations[1].RelationType)
+	assert.Equal(t, 180050, detail.Relations[1].ID)
+	assert.Equal(t, "OVA", detail.Relations[1].Format)
+	assert.Equal(t, 1, detail.Relations[1].Episodes)
+
+	// Verify characters
+	require.Len(t, detail.Characters, 2)
+
+	assert.Equal(t, 200001, detail.Characters[0].ID)
+	assert.Equal(t, "Hitori Gotou", detail.Characters[0].Name.Full)
+	assert.Equal(t, "後藤 ひとり", detail.Characters[0].Name.Native)
+	assert.Equal(t, "MAIN", detail.Characters[0].Role)
+
+	assert.Equal(t, 200002, detail.Characters[1].ID)
+	assert.Equal(t, "Nijika Ijichi", detail.Characters[1].Name.Full)
+	assert.Equal(t, "伊地知 虹夏", detail.Characters[1].Name.Native)
+	assert.Equal(t, "SUPPORTING", detail.Characters[1].Role)
+}
+
+func TestSearchAnime_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"message":"rate limited"}`))
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	results, err := client.SearchAnime(context.Background(), "test", 1, 10)
+	require.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "429")
+}
+
+func TestGetAnimeDetail_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]any{
+			"data": map[string]any{
+				"Media": nil,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+	detail, err := client.GetAnimeDetail(context.Background(), 9999999)
+	require.NoError(t, err)
+	assert.Nil(t, detail)
+}

--- a/internal/anilist/client_test.go
+++ b/internal/anilist/client_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,6 +108,7 @@ func TestGetAnimeDetail(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, float64(130003), req.Variables["id"])
 
+		// Flat relations -- no nesting inside nodes.
 		resp := map[string]any{
 			"data": map[string]any{
 				"Media": map[string]any{
@@ -210,7 +213,7 @@ func TestGetAnimeDetail(t *testing.T) {
 	assert.Equal(t, 12, detail.Episodes)
 	assert.Equal(t, "https://example.com/large.jpg", detail.CoverImage.Large)
 
-	// Verify relations
+	// Verify flat relations (2 edges from root, no nesting).
 	require.Len(t, detail.Relations, 2)
 
 	assert.Equal(t, "SEQUEL", detail.Relations[0].RelationType)
@@ -272,4 +275,47 @@ func TestGetAnimeDetail_NotFound(t *testing.T) {
 	detail, err := client.GetAnimeDetail(context.Background(), 9999999)
 	require.NoError(t, err)
 	assert.Nil(t, detail)
+}
+
+func TestThrottle(t *testing.T) {
+	var counter int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&counter, 1)
+		resp := map[string]any{
+			"data": map[string]any{
+				"Media": map[string]any{
+					"id": 1,
+					"title": map[string]any{
+						"romaji": "Test",
+					},
+					"format":     "TV",
+					"status":     "FINISHED",
+					"season":     "FALL",
+					"seasonYear": 2020,
+					"episodes":   12,
+					"coverImage": map[string]any{
+						"large":  "",
+						"medium": "",
+					},
+					"relations":  map[string]any{"edges": []any{}},
+					"characters": map[string]any{"edges": []any{}},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewHTTPClientWithEndpoint(server.URL)
+
+	start := time.Now()
+	_, err := client.GetAnimeDetail(context.Background(), 1)
+	require.NoError(t, err)
+	_, err = client.GetAnimeDetail(context.Background(), 1)
+	require.NoError(t, err)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, int64(2), atomic.LoadInt64(&counter), "both requests should reach the server")
+	assert.GreaterOrEqual(t, elapsed, 2*time.Second, "throttle should enforce at least 2s gap between requests")
 }

--- a/internal/anilist/types.go
+++ b/internal/anilist/types.go
@@ -1,0 +1,63 @@
+package anilist
+
+// MediaTitle holds the multi-language title variants returned by AniList.
+type MediaTitle struct {
+	Romaji  string `json:"romaji"`
+	English string `json:"english"`
+	Native  string `json:"native"`
+}
+
+// CoverImage holds cover image URLs.
+type CoverImage struct {
+	Large  string `json:"large"`
+	Medium string `json:"medium"`
+}
+
+// MediaSearchResult is a single result from an anime search.
+type MediaSearchResult struct {
+	ID         int        `json:"id"`
+	Title      MediaTitle `json:"title"`
+	Format     string     `json:"format"`     // TV, MOVIE, OVA, ONA, SPECIAL, etc.
+	Status     string     `json:"status"`     // FINISHED, RELEASING, NOT_YET_RELEASED, etc.
+	Season     string     `json:"season"`     // WINTER, SPRING, SUMMER, FALL
+	SeasonYear int        `json:"seasonYear"`
+	Episodes   int        `json:"episodes"`
+	CoverImage CoverImage `json:"coverImage"`
+}
+
+// Character is a character from an anime.
+type Character struct {
+	ID   int    `json:"id"`
+	Name struct {
+		Full   string `json:"full"`
+		Native string `json:"native"`
+	} `json:"name"`
+	Role string `json:"role"` // MAIN, SUPPORTING, BACKGROUND
+}
+
+// MediaRelation is a related anime (sequel, prequel, etc.).
+type MediaRelation struct {
+	RelationType string     `json:"relationType"` // SEQUEL, PREQUEL, SIDE_STORY, etc.
+	ID           int        `json:"id"`
+	Title        MediaTitle `json:"title"`
+	Type         string     `json:"type"`   // ANIME, MANGA
+	Format       string     `json:"format"` // TV, MOVIE, etc.
+	Status       string     `json:"status"`
+	Season       string     `json:"season"`
+	SeasonYear   int        `json:"seasonYear"`
+	Episodes     int        `json:"episodes"`
+}
+
+// MediaDetail is the full detail of an anime including relations and characters.
+type MediaDetail struct {
+	ID         int             `json:"id"`
+	Title      MediaTitle      `json:"title"`
+	Format     string          `json:"format"`
+	Status     string          `json:"status"`
+	Season     string          `json:"season"`
+	SeasonYear int             `json:"seasonYear"`
+	Episodes   int             `json:"episodes"`
+	CoverImage CoverImage      `json:"coverImage"`
+	Relations  []MediaRelation `json:"relations"`
+	Characters []Character     `json:"characters"`
+}

--- a/internal/anime/anilist_import.go
+++ b/internal/anime/anilist_import.go
@@ -246,32 +246,47 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 		displayName := sanitizeFolderName(group.baseTitle)
 		first := group.parts[0].detail
 
+		// parentID is the file ID of the season entry used as parent for sub-entries.
+		var parentID uint
+
 		if existing, ok := existingSeasonsByNum[seasonNum]; ok {
 			if err := s.updateEntryAiringInfo(ctx, existing.ID, first.Season, first.SeasonYear); err != nil {
 				return nil, fmt.Errorf("updateEntryAiringInfo for existing season %d: %w", seasonNum, err)
 			}
-			continue
-		}
-
-		created, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, &seasonNum, displayName)
-		if err != nil {
-			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
-				continue
+			parentID = existing.ID
+		} else {
+			created, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, &seasonNum, displayName)
+			if err != nil {
+				if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+					continue
+				}
+				return nil, fmt.Errorf("CreateEntry season %d: %w", seasonNum, err)
 			}
-			return nil, fmt.Errorf("CreateEntry season %d: %w", seasonNum, err)
-		}
-		result.EntriesCreated++
-		if err := s.updateEntryAiringInfo(ctx, created.ID, first.Season, first.SeasonYear); err != nil {
-			return nil, fmt.Errorf("updateEntryAiringInfo for season %d: %w", seasonNum, err)
+			result.EntriesCreated++
+			if err := s.updateEntryAiringInfo(ctx, created.ID, first.Season, first.SeasonYear); err != nil {
+				return nil, fmt.Errorf("updateEntryAiringInfo for season %d: %w", seasonNum, err)
+			}
+			parentID = created.ID
 		}
 
-		// Create sub-entries for multi-part groups.
+		// Create or update sub-entries for multi-part groups.
 		if len(group.parts) > 1 {
 			for _, part := range group.parts {
 				partName := fmt.Sprintf("Part %d", part.partNumber)
-				subEntry, err := s.CreateSubEntry(ctx, created.ID, partName)
+				subEntry, err := s.CreateSubEntry(ctx, parentID, partName)
 				if err != nil {
 					if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+						// Sub-entry already exists; look it up and update its airing info.
+						existingSub, findErr := s.dbClient.File().FindByValue(ctx, &db.File{
+							ParentID: parentID,
+							Name:     sanitizeFolderName(partName),
+						})
+						if findErr != nil {
+							return nil, fmt.Errorf("find existing sub-entry %s: %w", partName, findErr)
+						}
+						if err := s.updateEntryAiringInfo(ctx, existingSub.ID, part.detail.Season, part.detail.SeasonYear); err != nil {
+							return nil, fmt.Errorf("updateEntryAiringInfo for existing %s: %w", partName, err)
+						}
 						continue
 					}
 					return nil, fmt.Errorf("CreateSubEntry %s: %w", partName, err)

--- a/internal/anime/anilist_import.go
+++ b/internal/anime/anilist_import.go
@@ -1,0 +1,236 @@
+package anime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
+	"github.com/michael-freling/anime-image-viewer/internal/db"
+)
+
+// AniListImportResult summarises what was created during an AniList import.
+type AniListImportResult struct {
+	EntriesCreated    int `json:"entriesCreated"`
+	CharactersCreated int `json:"charactersCreated"`
+}
+
+// SearchAniList proxies a search request to the AniList client.
+func (s *Service) SearchAniList(ctx context.Context, query string) ([]anilist.MediaSearchResult, error) {
+	if s.anilistClient == nil {
+		return nil, fmt.Errorf("anilist client is not configured")
+	}
+	return s.anilistClient.SearchAnime(ctx, query, 1, 10)
+}
+
+// LinkAniList sets the AniListID on an anime record without performing a full
+// import. It verifies the anime exists first.
+func (s *Service) LinkAniList(ctx context.Context, animeID uint, aniListID int) error {
+	if s.anilistClient == nil {
+		return fmt.Errorf("anilist client is not configured")
+	}
+
+	row, err := s.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: animeID})
+	if err != nil {
+		if err == db.ErrRecordNotFound {
+			return fmt.Errorf("%w: id %d", ErrAnimeNotFound, animeID)
+		}
+		return err
+	}
+
+	row.AniListID = &aniListID
+	return s.dbClient.Anime().Update(ctx, &row)
+}
+
+// ImportFromAniList fetches detail from AniList and creates entries (seasons,
+// movies) and character tags for the given anime. The entire operation is
+// wrapped in a DB transaction so that a failure rolls back all changes (disk
+// folders created by CreateEntry are best-effort and not rolled back).
+func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID int) (*AniListImportResult, error) {
+	if s.anilistClient == nil {
+		return nil, fmt.Errorf("anilist client is not configured")
+	}
+
+	// Verify the anime exists.
+	_, err := s.Read(ctx, animeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch detail from AniList.
+	detail, err := s.anilistClient.GetAnimeDetail(ctx, aniListID)
+	if err != nil {
+		return nil, fmt.Errorf("anilist.GetAnimeDetail: %w", err)
+	}
+	if detail == nil {
+		return nil, fmt.Errorf("anilist: no detail found for id %d", aniListID)
+	}
+
+	result := &AniListImportResult{}
+
+	// 1. Link the anime to AniList by setting AniListID on the db.Anime record.
+	if err := s.LinkAniList(ctx, animeID, aniListID); err != nil {
+		return nil, fmt.Errorf("LinkAniList: %w", err)
+	}
+
+	// 2. Ensure Season 1 exists for the main anime and set its airing info.
+	season1Entry, created, err := s.ensureSeasonEntry(ctx, animeID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("ensureSeasonEntry for main anime: %w", err)
+	}
+	if created {
+		result.EntriesCreated++
+	}
+	if err := s.updateEntryAiringInfo(ctx, season1Entry.ID, detail.Season, detail.SeasonYear); err != nil {
+		return nil, fmt.Errorf("updateEntryAiringInfo for season 1: %w", err)
+	}
+
+	// 3. Process relations.
+	for _, rel := range detail.Relations {
+		if rel.Type != "ANIME" {
+			continue
+		}
+
+		switch {
+		case isSeasonFormat(rel.Format) && rel.RelationType == "SEQUEL":
+			entry, created, err := s.ensureSeasonEntry(ctx, animeID, nil)
+			if err != nil {
+				// Skip unique violations (entry already exists).
+				if isUniqueViolation(err) {
+					continue
+				}
+				return nil, fmt.Errorf("ensureSeasonEntry for sequel %d: %w", rel.ID, err)
+			}
+			if created {
+				result.EntriesCreated++
+			}
+			if err := s.updateEntryAiringInfo(ctx, entry.ID, rel.Season, rel.SeasonYear); err != nil {
+				return nil, fmt.Errorf("updateEntryAiringInfo for sequel: %w", err)
+			}
+
+		case rel.Format == "MOVIE" && isMovieRelationType(rel.RelationType):
+			displayName := relationDisplayName(rel)
+			var year *uint
+			if rel.SeasonYear > 0 {
+				y := uint(rel.SeasonYear)
+				year = &y
+			}
+			entry, err := s.CreateEntry(ctx, animeID, db.EntryTypeMovie, year, displayName)
+			if err != nil {
+				// Skip if the entry already exists (unique violation).
+				if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+					continue
+				}
+				return nil, fmt.Errorf("CreateEntry movie for %d: %w", rel.ID, err)
+			}
+			result.EntriesCreated++
+			if err := s.updateEntryAiringInfo(ctx, entry.ID, "", rel.SeasonYear); err != nil {
+				return nil, fmt.Errorf("updateEntryAiringInfo for movie: %w", err)
+			}
+		}
+	}
+
+	// 4. Create character tags.
+	existingTags, err := s.dbClient.Tag().FindTagsByAnimeID(animeID)
+	if err != nil {
+		return nil, fmt.Errorf("Tag.FindTagsByAnimeID: %w", err)
+	}
+	existingNames := make(map[string]bool, len(existingTags))
+	for _, t := range existingTags {
+		existingNames[t.Name] = true
+	}
+
+	for _, ch := range detail.Characters {
+		if ch.Role != "MAIN" && ch.Role != "SUPPORTING" {
+			continue
+		}
+		if ch.Name.Full == "" {
+			continue
+		}
+		if existingNames[ch.Name.Full] {
+			continue
+		}
+
+		aid := animeID
+		tag := db.Tag{
+			Name:     ch.Name.Full,
+			Category: "character",
+			AnimeID:  &aid,
+		}
+		if err := s.dbClient.Tag().Create(ctx, &tag); err != nil {
+			// Skip duplicates (e.g. if two characters share a name).
+			if isUniqueViolation(err) {
+				continue
+			}
+			return nil, fmt.Errorf("Tag.Create for character %q: %w", ch.Name.Full, err)
+		}
+		existingNames[ch.Name.Full] = true
+		result.CharactersCreated++
+	}
+
+	return result, nil
+}
+
+// ensureSeasonEntry creates the next season entry for the anime if needed.
+// When displayName is nil the auto-generated "Season N" name is used.
+// Returns the entry, whether it was newly created, and any error.
+func (s *Service) ensureSeasonEntry(ctx context.Context, animeID uint, displayName *string) (AnimeEntry, bool, error) {
+	name := ""
+	if displayName != nil {
+		name = *displayName
+	}
+	entry, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, nil, name)
+	if err != nil {
+		return AnimeEntry{}, false, err
+	}
+	return entry, true, nil
+}
+
+// updateEntryAiringInfo sets AiringSeason and AiringYear on a file entry.
+func (s *Service) updateEntryAiringInfo(ctx context.Context, fileID uint, season string, seasonYear int) error {
+	airingSeason := anilistSeasonToDBSeason(season)
+	var airingYear *uint
+	if seasonYear > 0 {
+		y := uint(seasonYear)
+		airingYear = &y
+	}
+	return s.dbClient.File().UpdateAiringFields(ctx, fileID, airingSeason, airingYear)
+}
+
+// anilistSeasonToDBSeason maps AniList season strings to DB constants.
+// AniList uses the same strings (WINTER, SPRING, SUMMER, FALL) so this is
+// mostly a pass-through with validation.
+func anilistSeasonToDBSeason(season string) string {
+	switch season {
+	case "WINTER":
+		return db.AiringSeasonWinter
+	case "SPRING":
+		return db.AiringSeasonSpring
+	case "SUMMER":
+		return db.AiringSeasonSummer
+	case "FALL":
+		return db.AiringSeasonFall
+	default:
+		return ""
+	}
+}
+
+// isSeasonFormat returns true if the AniList format indicates a TV-style
+// season entry.
+func isSeasonFormat(format string) bool {
+	return format == "TV" || format == "TV_SHORT" || format == "ONA"
+}
+
+// isMovieRelationType returns true if the relation type is one we import as
+// a movie entry.
+func isMovieRelationType(relationType string) bool {
+	return relationType == "SEQUEL" || relationType == "SIDE_STORY" || relationType == "PARENT"
+}
+
+// relationDisplayName picks the best display name from a relation's title.
+func relationDisplayName(rel anilist.MediaRelation) string {
+	if rel.Title.English != "" {
+		return rel.Title.English
+	}
+	return rel.Title.Romaji
+}

--- a/internal/anime/anilist_import.go
+++ b/internal/anime/anilist_import.go
@@ -3,7 +3,9 @@ package anime
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/michael-freling/anime-image-viewer/internal/anilist"
@@ -43,39 +45,190 @@ func (s *Service) LinkAniList(ctx context.Context, animeID uint, aniListID int) 
 	return s.dbClient.Anime().Update(ctx, &row)
 }
 
-// ImportFromAniList fetches detail from AniList, follows the SEQUEL/PREQUEL
-// chain to discover all seasons, and creates entries (seasons, movies) and
-// character tags for the given anime. Characters are deduplicated across all
-// entries in the chain.
+// sanitizeFolderName replaces characters that are invalid in folder names
+// with a dash. invalidFolderChars is defined in service.go.
+func sanitizeFolderName(name string) string {
+	return invalidFolderChars.ReplaceAllString(name, "-")
+}
+
+// partSuffixRe matches a trailing "Part N" suffix (case-insensitive) preceded
+// by at least one whitespace character.
+var partSuffixRe = regexp.MustCompile(`(?i)\s+Part\s+(\d+)\s*$`)
+
+// detailDisplayName picks the best display name from a MediaDetail's title.
+func detailDisplayName(detail *anilist.MediaDetail) string {
+	if detail.Title.English != "" {
+		return detail.Title.English
+	}
+	return detail.Title.Romaji
+}
+
+// parsePartSuffix extracts a "Part N" suffix from a title.
+// Returns the base title and the part number. If no suffix is found, partNumber is 0.
+func parsePartSuffix(title string) (baseTitle string, partNumber int) {
+	m := partSuffixRe.FindStringSubmatchIndex(title)
+	if m == nil {
+		return title, 0
+	}
+	base := strings.TrimSpace(title[:m[0]])
+	numStr := title[m[2]:m[3]]
+	n, _ := strconv.Atoi(numStr)
+	return base, n
+}
+
+type partEntry struct {
+	detail     *anilist.MediaDetail
+	fullTitle  string
+	partNumber int // 0 means no "Part N" suffix
+}
+
+type seasonGroup struct {
+	baseTitle string
+	parts     []partEntry
+}
+
+// groupSeasonsByPart groups a sorted slice of MediaDetail entries by base
+// title, detecting "Part N" suffixes to create multi-part groups.
+func groupSeasonsByPart(sortedDetails []*anilist.MediaDetail) []seasonGroup {
+	groupMap := make(map[string]*seasonGroup)
+	var groupOrder []string
+
+	for _, detail := range sortedDetails {
+		title := detailDisplayName(detail)
+		base, partNum := parsePartSuffix(title)
+
+		g, exists := groupMap[base]
+		if !exists {
+			g = &seasonGroup{baseTitle: base}
+			groupMap[base] = g
+			groupOrder = append(groupOrder, base)
+		}
+		g.parts = append(g.parts, partEntry{
+			detail:     detail,
+			fullTitle:  title,
+			partNumber: partNum,
+		})
+	}
+
+	result := make([]seasonGroup, 0, len(groupOrder))
+	for _, key := range groupOrder {
+		g := groupMap[key]
+		// If a group has >1 entry, any entry with partNumber==0 is implicitly Part 1.
+		if len(g.parts) > 1 {
+			for i := range g.parts {
+				if g.parts[i].partNumber == 0 {
+					g.parts[i].partNumber = 1
+				}
+			}
+		}
+		result = append(result, *g)
+	}
+	return result
+}
+
+// ImportFromAniList uses BFS to follow the SEQUEL/PREQUEL chain from the
+// selected AniList entry, fetching each season individually. This avoids
+// the query-complexity limit that nested GraphQL queries hit on AniList.
 func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID int) (*AniListImportResult, error) {
 	if s.anilistClient == nil {
 		return nil, fmt.Errorf("anilist client is not configured")
 	}
 
-	// Verify the anime exists.
 	_, err := s.Read(ctx, animeID)
 	if err != nil {
 		return nil, err
 	}
 
-	// 1. Fetch the full series chain by following SEQUEL/PREQUEL relations.
-	seriesEntries, movieRelations, err := s.fetchSeriesChain(ctx, aniListID)
-	if err != nil {
-		return nil, fmt.Errorf("fetchSeriesChain: %w", err)
-	}
-	if len(seriesEntries) == 0 {
-		return nil, fmt.Errorf("anilist: no detail found for id %d", aniListID)
+	// BFS: fetch root and follow SEQUEL/PREQUEL chain.
+	fetched := make(map[int]*anilist.MediaDetail)
+	queue := []int{aniListID}
+
+	for len(queue) > 0 {
+		currentID := queue[0]
+		queue = queue[1:]
+
+		if fetched[currentID] != nil {
+			continue
+		}
+
+		detail, err := s.anilistClient.GetAnimeDetail(ctx, currentID)
+		if err != nil {
+			return nil, fmt.Errorf("anilist.GetAnimeDetail(%d): %w", currentID, err)
+		}
+		if detail == nil {
+			continue
+		}
+		fetched[currentID] = detail
+
+		// Discover SEQUEL/PREQUEL TV/ONA relations to follow.
+		for _, rel := range detail.Relations {
+			if rel.Type != "ANIME" {
+				continue
+			}
+			if !isSeasonFormat(rel.Format) {
+				continue
+			}
+			if rel.RelationType != "SEQUEL" && rel.RelationType != "PREQUEL" {
+				continue
+			}
+			if fetched[rel.ID] == nil {
+				queue = append(queue, rel.ID)
+			}
+		}
 	}
 
 	result := &AniListImportResult{}
 
-	// 2. Link the anime to AniList by setting AniListID on the db.Anime record.
+	// Link anime to AniList.
 	if err := s.LinkAniList(ctx, animeID, aniListID); err != nil {
 		return nil, fmt.Errorf("LinkAniList: %w", err)
 	}
 
-	// 3. Build a map of existing season entries so we can skip duplicates and
-	//    update airing info on pre-existing seasons.
+	// Build season list from all fetched details.
+	type seasonInfo struct {
+		season     string
+		seasonYear int
+		id         int
+	}
+	var seasons []seasonInfo
+	var allMovieRelations []anilist.MediaRelation
+	seenMovies := make(map[int]bool)
+
+	for _, detail := range fetched {
+		// Each fetched entry is a season.
+		seasons = append(seasons, seasonInfo{
+			season:     detail.Season,
+			seasonYear: detail.SeasonYear,
+			id:         detail.ID,
+		})
+		// Collect movie relations from all entries.
+		for _, rel := range detail.Relations {
+			if rel.Type != "ANIME" || rel.Format != "MOVIE" || !isMovieRelationType(rel.RelationType) {
+				continue
+			}
+			if !seenMovies[rel.ID] {
+				seenMovies[rel.ID] = true
+				allMovieRelations = append(allMovieRelations, rel)
+			}
+		}
+	}
+
+	// Sort seasons by year, then AniList ID as tiebreaker.
+	sort.Slice(seasons, func(i, j int) bool {
+		if seasons[i].seasonYear != seasons[j].seasonYear {
+			return seasons[i].seasonYear < seasons[j].seasonYear
+		}
+		return seasons[i].id < seasons[j].id
+	})
+
+	// Build sorted detail list and group by base title.
+	sortedDetails := make([]*anilist.MediaDetail, len(seasons))
+	for i, si := range seasons {
+		sortedDetails[i] = fetched[si.id]
+	}
+	groups := groupSeasonsByPart(sortedDetails)
+
+	// Build map of existing season entries to skip duplicates.
 	existingEntries, err := s.GetAnimeEntries(animeID)
 	if err != nil {
 		return nil, fmt.Errorf("GetAnimeEntries: %w", err)
@@ -87,19 +240,20 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 		}
 	}
 
-	// 4. Create season entries from the chain (sorted by seasonYear).
-	for i, entry := range seriesEntries {
+	// Create season entries from groups.
+	for i, group := range groups {
 		seasonNum := uint(i + 1)
+		displayName := sanitizeFolderName(group.baseTitle)
+		first := group.parts[0].detail
 
 		if existing, ok := existingSeasonsByNum[seasonNum]; ok {
-			// Season already exists — just update its airing info.
-			if err := s.updateEntryAiringInfo(ctx, existing.ID, entry.Season, entry.SeasonYear); err != nil {
+			if err := s.updateEntryAiringInfo(ctx, existing.ID, first.Season, first.SeasonYear); err != nil {
 				return nil, fmt.Errorf("updateEntryAiringInfo for existing season %d: %w", seasonNum, err)
 			}
 			continue
 		}
 
-		created, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, &seasonNum, fmt.Sprintf("Season %d", seasonNum))
+		created, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, &seasonNum, displayName)
 		if err != nil {
 			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
 				continue
@@ -107,14 +261,33 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 			return nil, fmt.Errorf("CreateEntry season %d: %w", seasonNum, err)
 		}
 		result.EntriesCreated++
-		if err := s.updateEntryAiringInfo(ctx, created.ID, entry.Season, entry.SeasonYear); err != nil {
+		if err := s.updateEntryAiringInfo(ctx, created.ID, first.Season, first.SeasonYear); err != nil {
 			return nil, fmt.Errorf("updateEntryAiringInfo for season %d: %w", seasonNum, err)
+		}
+
+		// Create sub-entries for multi-part groups.
+		if len(group.parts) > 1 {
+			for _, part := range group.parts {
+				partName := fmt.Sprintf("Part %d", part.partNumber)
+				subEntry, err := s.CreateSubEntry(ctx, created.ID, partName)
+				if err != nil {
+					if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+						continue
+					}
+					return nil, fmt.Errorf("CreateSubEntry %s: %w", partName, err)
+				}
+				result.EntriesCreated++
+				// Set airing info on the part from its AniList detail.
+				if err := s.updateEntryAiringInfo(ctx, subEntry.ID, part.detail.Season, part.detail.SeasonYear); err != nil {
+					return nil, fmt.Errorf("updateEntryAiringInfo for %s: %w", partName, err)
+				}
+			}
 		}
 	}
 
-	// 5. Create movie entries from movie relations found across the chain.
-	for _, rel := range movieRelations {
-		displayName := relationDisplayName(rel)
+	// Create movie entries with sanitized names.
+	for _, rel := range allMovieRelations {
+		displayName := sanitizeFolderName(relationDisplayName(rel))
 		var year *uint
 		if rel.SeasonYear > 0 {
 			y := uint(rel.SeasonYear)
@@ -125,14 +298,12 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
 				continue
 			}
-			return nil, fmt.Errorf("CreateEntry movie for %d: %w", rel.ID, err)
+			return nil, fmt.Errorf("CreateEntry movie: %w", err)
 		}
 		result.EntriesCreated++
 	}
 
-	// 6. Collect ALL characters from ALL fetched entries, deduplicate by name.
-	allCharacters := collectUniqueCharacters(seriesEntries)
-
+	// Collect characters from ALL fetched entries, dedup by name.
 	existingTags, err := s.dbClient.Tag().FindTagsByAnimeID(animeID)
 	if err != nil {
 		return nil, fmt.Errorf("Tag.FindTagsByAnimeID: %w", err)
@@ -142,111 +313,32 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 		existingNames[t.Name] = true
 	}
 
-	for _, ch := range allCharacters {
-		if existingNames[ch.Name.Full] {
-			continue
-		}
-
-		aid := animeID
-		tag := db.Tag{
-			Name:     ch.Name.Full,
-			Category: "character",
-			AnimeID:  &aid,
-		}
-		if err := s.dbClient.Tag().Create(ctx, &tag); err != nil {
-			if isUniqueViolation(err) {
-				continue
-			}
-			return nil, fmt.Errorf("Tag.Create for character %q: %w", ch.Name.Full, err)
-		}
-		existingNames[ch.Name.Full] = true
-		result.CharactersCreated++
-	}
-
-	return result, nil
-}
-
-// fetchSeriesChain follows SEQUEL and PREQUEL relations from the starting
-// entry to discover all seasons in the series via BFS. It returns:
-//   - a list of MediaDetail entries sorted by seasonYear (then by ID) representing seasons
-//   - a list of MOVIE relations found across all entries in the chain
-func (s *Service) fetchSeriesChain(ctx context.Context, startID int) ([]*anilist.MediaDetail, []anilist.MediaRelation, error) {
-	visited := map[int]bool{}
-	var seasonEntries []*anilist.MediaDetail
-	var movieRelations []anilist.MediaRelation
-	seenMovies := map[int]bool{}
-	queue := []int{startID}
-
-	for len(queue) > 0 {
-		id := queue[0]
-		queue = queue[1:]
-		if visited[id] {
-			continue
-		}
-		visited[id] = true
-
-		detail, err := s.anilistClient.GetAnimeDetail(ctx, id)
-		if err != nil {
-			return nil, nil, fmt.Errorf("anilist.GetAnimeDetail(%d): %w", id, err)
-		}
-		if detail == nil {
-			continue
-		}
-
-		seasonEntries = append(seasonEntries, detail)
-
-		for _, rel := range detail.Relations {
-			if rel.Type != "ANIME" {
-				continue
-			}
-
-			// Follow TV-format SEQUEL/PREQUEL to find more seasons.
-			if isSeasonFormat(rel.Format) && (rel.RelationType == "SEQUEL" || rel.RelationType == "PREQUEL") {
-				if !visited[rel.ID] {
-					queue = append(queue, rel.ID)
-				}
-			}
-
-			// Collect MOVIE relations (don't follow them in the chain).
-			if rel.Format == "MOVIE" && isMovieRelationType(rel.RelationType) && !seenMovies[rel.ID] {
-				seenMovies[rel.ID] = true
-				movieRelations = append(movieRelations, rel)
-			}
-		}
-	}
-
-	// Sort seasons by seasonYear, then by AniList ID as tiebreaker.
-	sort.Slice(seasonEntries, func(i, j int) bool {
-		if seasonEntries[i].SeasonYear != seasonEntries[j].SeasonYear {
-			return seasonEntries[i].SeasonYear < seasonEntries[j].SeasonYear
-		}
-		return seasonEntries[i].ID < seasonEntries[j].ID
-	})
-
-	return seasonEntries, movieRelations, nil
-}
-
-// collectUniqueCharacters gathers characters from all entries and deduplicates
-// by Name.Full. Only MAIN and SUPPORTING roles are included.
-func collectUniqueCharacters(entries []*anilist.MediaDetail) []anilist.Character {
-	seen := map[string]bool{}
-	var result []anilist.Character
-	for _, entry := range entries {
-		for _, ch := range entry.Characters {
+	for _, detail := range fetched {
+		for _, ch := range detail.Characters {
 			if ch.Role != "MAIN" && ch.Role != "SUPPORTING" {
 				continue
 			}
-			if ch.Name.Full == "" {
+			if ch.Name.Full == "" || existingNames[ch.Name.Full] {
 				continue
 			}
-			if seen[ch.Name.Full] {
-				continue
+			aid := animeID
+			tag := db.Tag{
+				Name:     ch.Name.Full,
+				Category: "character",
+				AnimeID:  &aid,
 			}
-			seen[ch.Name.Full] = true
-			result = append(result, ch)
+			if err := s.dbClient.Tag().Create(ctx, &tag); err != nil {
+				if isUniqueViolation(err) {
+					continue
+				}
+				return nil, fmt.Errorf("Tag.Create for character %q: %w", ch.Name.Full, err)
+			}
+			existingNames[ch.Name.Full] = true
+			result.CharactersCreated++
 		}
 	}
-	return result
+
+	return result, nil
 }
 
 // updateEntryAiringInfo sets AiringSeason and AiringYear on a file entry.
@@ -297,3 +389,4 @@ func relationDisplayName(rel anilist.MediaRelation) string {
 	}
 	return rel.Title.Romaji
 }
+

--- a/internal/anime/anilist_import.go
+++ b/internal/anime/anilist_import.go
@@ -3,6 +3,7 @@ package anime
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/michael-freling/anime-image-viewer/internal/anilist"
@@ -42,10 +43,10 @@ func (s *Service) LinkAniList(ctx context.Context, animeID uint, aniListID int) 
 	return s.dbClient.Anime().Update(ctx, &row)
 }
 
-// ImportFromAniList fetches detail from AniList and creates entries (seasons,
-// movies) and character tags for the given anime. The entire operation is
-// wrapped in a DB transaction so that a failure rolls back all changes (disk
-// folders created by CreateEntry are best-effort and not rolled back).
+// ImportFromAniList fetches detail from AniList, follows the SEQUEL/PREQUEL
+// chain to discover all seasons, and creates entries (seasons, movies) and
+// character tags for the given anime. Characters are deduplicated across all
+// entries in the chain.
 func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID int) (*AniListImportResult, error) {
 	if s.anilistClient == nil {
 		return nil, fmt.Errorf("anilist client is not configured")
@@ -57,80 +58,81 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 		return nil, err
 	}
 
-	// Fetch detail from AniList.
-	detail, err := s.anilistClient.GetAnimeDetail(ctx, aniListID)
+	// 1. Fetch the full series chain by following SEQUEL/PREQUEL relations.
+	seriesEntries, movieRelations, err := s.fetchSeriesChain(ctx, aniListID)
 	if err != nil {
-		return nil, fmt.Errorf("anilist.GetAnimeDetail: %w", err)
+		return nil, fmt.Errorf("fetchSeriesChain: %w", err)
 	}
-	if detail == nil {
+	if len(seriesEntries) == 0 {
 		return nil, fmt.Errorf("anilist: no detail found for id %d", aniListID)
 	}
 
 	result := &AniListImportResult{}
 
-	// 1. Link the anime to AniList by setting AniListID on the db.Anime record.
+	// 2. Link the anime to AniList by setting AniListID on the db.Anime record.
 	if err := s.LinkAniList(ctx, animeID, aniListID); err != nil {
 		return nil, fmt.Errorf("LinkAniList: %w", err)
 	}
 
-	// 2. Ensure Season 1 exists for the main anime and set its airing info.
-	season1Entry, created, err := s.ensureSeasonEntry(ctx, animeID, nil)
+	// 3. Build a map of existing season entries so we can skip duplicates and
+	//    update airing info on pre-existing seasons.
+	existingEntries, err := s.GetAnimeEntries(animeID)
 	if err != nil {
-		return nil, fmt.Errorf("ensureSeasonEntry for main anime: %w", err)
+		return nil, fmt.Errorf("GetAnimeEntries: %w", err)
 	}
-	if created {
-		result.EntriesCreated++
-	}
-	if err := s.updateEntryAiringInfo(ctx, season1Entry.ID, detail.Season, detail.SeasonYear); err != nil {
-		return nil, fmt.Errorf("updateEntryAiringInfo for season 1: %w", err)
+	existingSeasonsByNum := make(map[uint]AnimeEntry)
+	for _, e := range existingEntries {
+		if e.EntryType == db.EntryTypeSeason && e.EntryNumber != nil {
+			existingSeasonsByNum[*e.EntryNumber] = e
+		}
 	}
 
-	// 3. Process relations.
-	for _, rel := range detail.Relations {
-		if rel.Type != "ANIME" {
+	// 4. Create season entries from the chain (sorted by seasonYear).
+	for i, entry := range seriesEntries {
+		seasonNum := uint(i + 1)
+
+		if existing, ok := existingSeasonsByNum[seasonNum]; ok {
+			// Season already exists — just update its airing info.
+			if err := s.updateEntryAiringInfo(ctx, existing.ID, entry.Season, entry.SeasonYear); err != nil {
+				return nil, fmt.Errorf("updateEntryAiringInfo for existing season %d: %w", seasonNum, err)
+			}
 			continue
 		}
 
-		switch {
-		case isSeasonFormat(rel.Format) && rel.RelationType == "SEQUEL":
-			entry, created, err := s.ensureSeasonEntry(ctx, animeID, nil)
-			if err != nil {
-				// Skip unique violations (entry already exists).
-				if isUniqueViolation(err) {
-					continue
-				}
-				return nil, fmt.Errorf("ensureSeasonEntry for sequel %d: %w", rel.ID, err)
+		created, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, &seasonNum, fmt.Sprintf("Season %d", seasonNum))
+		if err != nil {
+			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+				continue
 			}
-			if created {
-				result.EntriesCreated++
-			}
-			if err := s.updateEntryAiringInfo(ctx, entry.ID, rel.Season, rel.SeasonYear); err != nil {
-				return nil, fmt.Errorf("updateEntryAiringInfo for sequel: %w", err)
-			}
-
-		case rel.Format == "MOVIE" && isMovieRelationType(rel.RelationType):
-			displayName := relationDisplayName(rel)
-			var year *uint
-			if rel.SeasonYear > 0 {
-				y := uint(rel.SeasonYear)
-				year = &y
-			}
-			entry, err := s.CreateEntry(ctx, animeID, db.EntryTypeMovie, year, displayName)
-			if err != nil {
-				// Skip if the entry already exists (unique violation).
-				if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
-					continue
-				}
-				return nil, fmt.Errorf("CreateEntry movie for %d: %w", rel.ID, err)
-			}
-			result.EntriesCreated++
-			if err := s.updateEntryAiringInfo(ctx, entry.ID, "", rel.SeasonYear); err != nil {
-				return nil, fmt.Errorf("updateEntryAiringInfo for movie: %w", err)
-			}
+			return nil, fmt.Errorf("CreateEntry season %d: %w", seasonNum, err)
+		}
+		result.EntriesCreated++
+		if err := s.updateEntryAiringInfo(ctx, created.ID, entry.Season, entry.SeasonYear); err != nil {
+			return nil, fmt.Errorf("updateEntryAiringInfo for season %d: %w", seasonNum, err)
 		}
 	}
 
-	// 4. Create character tags.
+	// 5. Create movie entries from movie relations found across the chain.
+	for _, rel := range movieRelations {
+		displayName := relationDisplayName(rel)
+		var year *uint
+		if rel.SeasonYear > 0 {
+			y := uint(rel.SeasonYear)
+			year = &y
+		}
+		_, err := s.CreateEntry(ctx, animeID, db.EntryTypeMovie, year, displayName)
+		if err != nil {
+			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+				continue
+			}
+			return nil, fmt.Errorf("CreateEntry movie for %d: %w", rel.ID, err)
+		}
+		result.EntriesCreated++
+	}
+
+	// 6. Collect ALL characters from ALL fetched entries, deduplicate by name.
+	allCharacters := collectUniqueCharacters(seriesEntries)
+
 	existingTags, err := s.dbClient.Tag().FindTagsByAnimeID(animeID)
 	if err != nil {
 		return nil, fmt.Errorf("Tag.FindTagsByAnimeID: %w", err)
@@ -140,13 +142,7 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 		existingNames[t.Name] = true
 	}
 
-	for _, ch := range detail.Characters {
-		if ch.Role != "MAIN" && ch.Role != "SUPPORTING" {
-			continue
-		}
-		if ch.Name.Full == "" {
-			continue
-		}
+	for _, ch := range allCharacters {
 		if existingNames[ch.Name.Full] {
 			continue
 		}
@@ -158,7 +154,6 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 			AnimeID:  &aid,
 		}
 		if err := s.dbClient.Tag().Create(ctx, &tag); err != nil {
-			// Skip duplicates (e.g. if two characters share a name).
 			if isUniqueViolation(err) {
 				continue
 			}
@@ -171,19 +166,87 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 	return result, nil
 }
 
-// ensureSeasonEntry creates the next season entry for the anime if needed.
-// When displayName is nil the auto-generated "Season N" name is used.
-// Returns the entry, whether it was newly created, and any error.
-func (s *Service) ensureSeasonEntry(ctx context.Context, animeID uint, displayName *string) (AnimeEntry, bool, error) {
-	name := ""
-	if displayName != nil {
-		name = *displayName
+// fetchSeriesChain follows SEQUEL and PREQUEL relations from the starting
+// entry to discover all seasons in the series via BFS. It returns:
+//   - a list of MediaDetail entries sorted by seasonYear (then by ID) representing seasons
+//   - a list of MOVIE relations found across all entries in the chain
+func (s *Service) fetchSeriesChain(ctx context.Context, startID int) ([]*anilist.MediaDetail, []anilist.MediaRelation, error) {
+	visited := map[int]bool{}
+	var seasonEntries []*anilist.MediaDetail
+	var movieRelations []anilist.MediaRelation
+	seenMovies := map[int]bool{}
+	queue := []int{startID}
+
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if visited[id] {
+			continue
+		}
+		visited[id] = true
+
+		detail, err := s.anilistClient.GetAnimeDetail(ctx, id)
+		if err != nil {
+			return nil, nil, fmt.Errorf("anilist.GetAnimeDetail(%d): %w", id, err)
+		}
+		if detail == nil {
+			continue
+		}
+
+		seasonEntries = append(seasonEntries, detail)
+
+		for _, rel := range detail.Relations {
+			if rel.Type != "ANIME" {
+				continue
+			}
+
+			// Follow TV-format SEQUEL/PREQUEL to find more seasons.
+			if isSeasonFormat(rel.Format) && (rel.RelationType == "SEQUEL" || rel.RelationType == "PREQUEL") {
+				if !visited[rel.ID] {
+					queue = append(queue, rel.ID)
+				}
+			}
+
+			// Collect MOVIE relations (don't follow them in the chain).
+			if rel.Format == "MOVIE" && isMovieRelationType(rel.RelationType) && !seenMovies[rel.ID] {
+				seenMovies[rel.ID] = true
+				movieRelations = append(movieRelations, rel)
+			}
+		}
 	}
-	entry, err := s.CreateEntry(ctx, animeID, db.EntryTypeSeason, nil, name)
-	if err != nil {
-		return AnimeEntry{}, false, err
+
+	// Sort seasons by seasonYear, then by AniList ID as tiebreaker.
+	sort.Slice(seasonEntries, func(i, j int) bool {
+		if seasonEntries[i].SeasonYear != seasonEntries[j].SeasonYear {
+			return seasonEntries[i].SeasonYear < seasonEntries[j].SeasonYear
+		}
+		return seasonEntries[i].ID < seasonEntries[j].ID
+	})
+
+	return seasonEntries, movieRelations, nil
+}
+
+// collectUniqueCharacters gathers characters from all entries and deduplicates
+// by Name.Full. Only MAIN and SUPPORTING roles are included.
+func collectUniqueCharacters(entries []*anilist.MediaDetail) []anilist.Character {
+	seen := map[string]bool{}
+	var result []anilist.Character
+	for _, entry := range entries {
+		for _, ch := range entry.Characters {
+			if ch.Role != "MAIN" && ch.Role != "SUPPORTING" {
+				continue
+			}
+			if ch.Name.Full == "" {
+				continue
+			}
+			if seen[ch.Name.Full] {
+				continue
+			}
+			seen[ch.Name.Full] = true
+			result = append(result, ch)
+		}
 	}
-	return entry, true, nil
+	return result
 }
 
 // updateEntryAiringInfo sets AiringSeason and AiringYear on a file entry.

--- a/internal/anime/anilist_import.go
+++ b/internal/anime/anilist_import.go
@@ -301,21 +301,61 @@ func (s *Service) ImportFromAniList(ctx context.Context, animeID uint, aniListID
 	}
 
 	// Create movie entries with sanitized names.
+	// Fetch full details for each movie individually, since relation edges
+	// often have incomplete data (e.g. SeasonYear: 0).
 	for _, rel := range allMovieRelations {
-		displayName := sanitizeFolderName(relationDisplayName(rel))
+		movieDetail, err := s.anilistClient.GetAnimeDetail(ctx, rel.ID)
+		if err != nil {
+			// Log/skip gracefully rather than failing the entire import.
+			movieDetail = nil
+		}
+
+		// Determine display name, season, and year from the fetched detail,
+		// falling back to the relation edge data when the detail is unavailable.
+		var displayName string
+		var movieSeason string
+		var movieSeasonYear int
+		if movieDetail != nil {
+			displayName = sanitizeFolderName(detailDisplayName(movieDetail))
+			movieSeason = movieDetail.Season
+			movieSeasonYear = movieDetail.SeasonYear
+		} else {
+			displayName = sanitizeFolderName(relationDisplayName(rel))
+			movieSeason = rel.Season
+			movieSeasonYear = rel.SeasonYear
+		}
+
 		var year *uint
-		if rel.SeasonYear > 0 {
-			y := uint(rel.SeasonYear)
+		if movieSeasonYear > 0 {
+			y := uint(movieSeasonYear)
 			year = &y
 		}
-		_, err := s.CreateEntry(ctx, animeID, db.EntryTypeMovie, year, displayName)
+		created, err := s.CreateEntry(ctx, animeID, db.EntryTypeMovie, year, displayName)
 		if err != nil {
 			if isUniqueViolation(err) || strings.Contains(err.Error(), "already exists") {
+				// Movie already exists; look it up and update its airing info.
+				rootFolder, findErr := s.FindAnimeRootFolder(animeID)
+				if findErr != nil {
+					return nil, fmt.Errorf("FindAnimeRootFolder for existing movie: %w", findErr)
+				}
+				existingMovie, findErr := s.dbClient.File().FindByValue(ctx, &db.File{
+					ParentID: rootFolder.ID,
+					Name:     displayName,
+				})
+				if findErr != nil {
+					return nil, fmt.Errorf("find existing movie %s: %w", displayName, findErr)
+				}
+				if err := s.updateEntryAiringInfo(ctx, existingMovie.ID, movieSeason, movieSeasonYear); err != nil {
+					return nil, fmt.Errorf("updateEntryAiringInfo for existing movie %s: %w", displayName, err)
+				}
 				continue
 			}
 			return nil, fmt.Errorf("CreateEntry movie: %w", err)
 		}
 		result.EntriesCreated++
+		if err := s.updateEntryAiringInfo(ctx, created.ID, movieSeason, movieSeasonYear); err != nil {
+			return nil, fmt.Errorf("updateEntryAiringInfo for movie %s: %w", displayName, err)
+		}
 	}
 
 	// Collect characters from ALL fetched entries, dedup by name.

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -156,6 +156,17 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
 				},
 			},
+			// Full detail for the movie (fetched individually for accurate data).
+			99999: {
+				ID: 99999,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Movie",
+					English: "Attack on Titan Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SUMMER",
+				SeasonYear: 2015,
+			},
 		},
 	}
 
@@ -236,8 +247,18 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 		}
 	}
 
-	// BFS makes 3 API calls (one per season).
-	assert.Equal(t, 3, mock.callCount, "BFS should make 3 API calls (one per season)")
+	// Verify movie has airing info from the individually-fetched detail.
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonSummer, child.AiringSeason, "movie should have SUMMER season from fetched detail")
+			require.NotNil(t, child.AiringYear, "movie should have airing year from fetched detail")
+			assert.Equal(t, uint(2015), *child.AiringYear, "movie should have year 2015 from fetched detail")
+			break
+		}
+	}
+
+	// BFS makes 3 API calls (one per season) + 1 movie detail fetch = 4.
+	assert.Equal(t, 4, mock.callCount, "BFS should make 3 API calls (one per season) + 1 movie detail fetch")
 }
 
 func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
@@ -587,6 +608,17 @@ func TestImportFromAniList_SanitizesMovieNames(t *testing.T) {
 						SeasonYear: 2022,
 					},
 				},
+			},
+			// Full detail for the movie (fetched individually).
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series: The Movie",
+					English: "Series: The Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SPRING",
+				SeasonYear: 2022,
 			},
 		},
 	}
@@ -1154,6 +1186,16 @@ func TestImportFromAniList_MovieWithParentRelation(t *testing.T) {
 					},
 				},
 			},
+			// Full detail for the movie.
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					English: "The Parent Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SPRING",
+				SeasonYear: 2022,
+			},
 		},
 	}
 
@@ -1271,7 +1313,9 @@ func TestImportFromAniList_MovieWithZeroYear(t *testing.T) {
 	te := newTester(t)
 	ctx := context.Background()
 
-	// Movie relation with SeasonYear 0 -- year should be nil.
+	// Movie relation edge has SeasonYear 0, but fetched detail has the real year.
+	// This verifies the fix: individual detail fetch overrides the incomplete
+	// relation edge data.
 	mock := &mockAniListClient{
 		detailResults: map[int]*anilist.MediaDetail{
 			100: {
@@ -1291,9 +1335,19 @@ func TestImportFromAniList_MovieWithZeroYear(t *testing.T) {
 						},
 						Type:       "ANIME",
 						Format:     "MOVIE",
-						SeasonYear: 0,
+						SeasonYear: 0, // Incomplete on the relation edge
 					},
 				},
+			},
+			// Full detail has the actual year and season.
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					English: "Yearless Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SUMMER",
+				SeasonYear: 2021,
 			},
 		},
 	}
@@ -1308,12 +1362,27 @@ func TestImportFromAniList_MovieWithZeroYear(t *testing.T) {
 	// 1 season + 1 movie = 2
 	assert.Equal(t, 2, result.EntriesCreated)
 
-	// Verify the movie has nil year.
+	// Verify the movie now has the year from the fetched detail (was 0 on edge).
 	entries, err := svc.GetAnimeEntries(created.ID)
 	require.NoError(t, err)
 	for _, e := range entries {
 		if e.EntryType == db.EntryTypeMovie {
-			assert.Nil(t, e.EntryNumber, "movie with zero year should have nil entry_number")
+			require.NotNil(t, e.EntryNumber, "movie should have year from fetched detail")
+			assert.Equal(t, uint(2021), *e.EntryNumber, "movie year should be 2021 from fetched detail")
+		}
+	}
+
+	// Verify movie airing info.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonSummer, child.AiringSeason, "movie should have SUMMER season")
+			require.NotNil(t, child.AiringYear, "movie should have airing year")
+			assert.Equal(t, uint(2021), *child.AiringYear, "movie should have year 2021")
+			break
 		}
 	}
 }
@@ -1533,6 +1602,16 @@ func TestImportFromAniList_DuplicateMovieDedup(t *testing.T) {
 					},
 				},
 			},
+			// Full detail for the movie.
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					English: "The Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "FALL",
+				SeasonYear: 2021,
+			},
 		},
 	}
 
@@ -1638,6 +1717,16 @@ func TestImportFromAniList_RomajiOnlyTitles(t *testing.T) {
 						SeasonYear: 2015,
 					},
 				},
+			},
+			// Full detail for the movie (Romaji only).
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					Romaji: "Shingeki no Kyojin Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SPRING",
+				SeasonYear: 2015,
 			},
 		},
 	}
@@ -1835,6 +1924,240 @@ func TestImportFromAniList_ReimportUpdatesExistingSubEntryAiringInfo(t *testing.
 			assert.Equal(t, db.AiringSeasonFall, child.AiringSeason, "parent season should have updated FALL season")
 			require.NotNil(t, child.AiringYear, "parent season should have airing year set")
 			assert.Equal(t, uint(2020), *child.AiringYear, "parent season should have updated year 2020")
+			break
+		}
+	}
+}
+
+func TestImportFromAniList_MovieDetailFetchFailsFallsBack(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// The movie detail fetch returns nil (not in detailResults).
+	// The code falls back to the relation edge data.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "FallbackShow",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "Fallback Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						Season:     "FALL",
+						SeasonYear: 2021,
+					},
+				},
+			},
+			// ID 999 intentionally omitted -- GetAnimeDetail returns nil.
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "FallbackTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season + 1 movie = 2
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify movie uses fallback data from the relation edge.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, "Fallback Movie", e.Name, "movie name should come from relation edge")
+			require.NotNil(t, e.EntryNumber, "movie should have year from relation edge")
+			assert.Equal(t, uint(2021), *e.EntryNumber)
+		}
+	}
+
+	// Verify airing info from the relation edge fallback.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonFall, child.AiringSeason, "movie should have FALL season from edge fallback")
+			require.NotNil(t, child.AiringYear, "movie should have airing year from edge fallback")
+			assert.Equal(t, uint(2021), *child.AiringYear, "movie should have year 2021 from edge fallback")
+			break
+		}
+	}
+}
+
+func TestImportFromAniList_MovieDetailOverridesEdgeData(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Relation edge has incomplete data (SeasonYear: 0, no English title).
+	// Full detail has accurate data. This verifies the core bug fix.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "DetailOverrideShow",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2019,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           888,
+						Title: anilist.MediaTitle{
+							Romaji: "Incomplete Edge Title",
+							// No English title on the edge
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 0, // Missing on edge
+						Season:     "", // Missing on edge
+					},
+				},
+			},
+			// Full detail has complete data including English title.
+			888: {
+				ID: 888,
+				Title: anilist.MediaTitle{
+					English: "The Complete Movie Title",
+					Romaji:  "Incomplete Edge Title",
+				},
+				Format:     "MOVIE",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "DetailOverride")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify movie uses the fetched detail's English title (not edge Romaji).
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, "The Complete Movie Title", e.Name, "movie name should prefer fetched detail's English title")
+			require.NotNil(t, e.EntryNumber, "movie should have year from fetched detail")
+			assert.Equal(t, uint(2020), *e.EntryNumber)
+		}
+	}
+
+	// Verify airing info from the fetched detail.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonWinter, child.AiringSeason, "movie should have WINTER season from detail")
+			require.NotNil(t, child.AiringYear, "movie should have airing year from detail")
+			assert.Equal(t, uint(2020), *child.AiringYear, "movie should have year 2020 from detail")
+			break
+		}
+	}
+}
+
+func TestImportFromAniList_ReimportUpdatesExistingMovieAiringInfo(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "MovieReimport",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "The Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 0,
+					},
+				},
+			},
+			999: {
+				ID: 999,
+				Title: anilist.MediaTitle{
+					English: "The Movie",
+				},
+				Format:     "MOVIE",
+				Season:     "SPRING",
+				SeasonYear: 2021,
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "MovieReimportTest")
+	require.NoError(t, err)
+
+	// First import: creates season + movie.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify initial movie airing info.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonSpring, child.AiringSeason)
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2021), *child.AiringYear)
+			break
+		}
+	}
+
+	// Update mock to simulate corrected AniList data.
+	mock.detailResults[999].Season = "SUMMER"
+	mock.detailResults[999].SeasonYear = 2022
+
+	// Second import: movie already exists, but airing info should be updated.
+	result2, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result2.EntriesCreated, "re-import should not create new entries")
+
+	// Verify movie airing info was updated.
+	children2, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children2 {
+		if child.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, db.AiringSeasonSummer, child.AiringSeason, "movie should have updated SUMMER season")
+			require.NotNil(t, child.AiringYear, "movie should have airing year")
+			assert.Equal(t, uint(2022), *child.AiringYear, "movie should have updated year 2022")
 			break
 		}
 	}

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -16,6 +16,7 @@ type mockAniListClient struct {
 	searchErr     error
 	detailResults map[int]*anilist.MediaDetail // keyed by AniList ID
 	detailErr     error
+	callCount     int // number of GetAnimeDetail calls made
 }
 
 func (m *mockAniListClient) SearchAnime(_ context.Context, _ string, _ int, _ int) ([]anilist.MediaSearchResult, error) {
@@ -23,6 +24,7 @@ func (m *mockAniListClient) SearchAnime(_ context.Context, _ string, _ int, _ in
 }
 
 func (m *mockAniListClient) GetAnimeDetail(_ context.Context, id int) (*anilist.MediaDetail, error) {
+	m.callCount++
 	if m.detailErr != nil {
 		return nil, m.detailErr
 	}
@@ -33,6 +35,8 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 	te := newTester(t)
 	ctx := context.Background()
 
+	// BFS: each season has its own entry in detailResults. The BFS traversal
+	// fetches each one individually via flat SEQUEL/PREQUEL relations.
 	mock := &mockAniListClient{
 		detailResults: map[int]*anilist.MediaDetail{
 			100: {
@@ -92,14 +96,8 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 					{
 						RelationType: "PREQUEL",
 						ID:           100,
-						Title: anilist.MediaTitle{
-							Romaji:  "Shingeki no Kyojin",
-							English: "Attack on Titan",
-						},
-						Type:       "ANIME",
-						Format:     "TV",
-						Season:     "SPRING",
-						SeasonYear: 2013,
+						Type:         "ANIME",
+						Format:       "TV",
 					},
 					{
 						RelationType: "SEQUEL",
@@ -126,16 +124,6 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 					},
 				},
 				Characters: []anilist.Character{
-					// Duplicates of Season 1 characters.
-					{ID: 1, Role: "MAIN", Name: struct {
-						Full   string `json:"full"`
-						Native string `json:"native"`
-					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
-					{ID: 2, Role: "MAIN", Name: struct {
-						Full   string `json:"full"`
-						Native string `json:"native"`
-					}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
-					// New character in Season 2.
 					{ID: 3, Role: "SUPPORTING", Name: struct {
 						Full   string `json:"full"`
 						Native string `json:"native"`
@@ -155,35 +143,16 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 					{
 						RelationType: "PREQUEL",
 						ID:           200,
-						Title: anilist.MediaTitle{
-							Romaji:  "Shingeki no Kyojin Season 2",
-							English: "Attack on Titan Season 2",
-						},
-						Type:       "ANIME",
-						Format:     "TV",
-						Season:     "SPRING",
-						SeasonYear: 2017,
+						Type:         "ANIME",
+						Format:       "TV",
 					},
 				},
 				Characters: []anilist.Character{
-					// All duplicates.
+					// Duplicate of Eren from ID 100 -- should be deduped.
 					{ID: 1, Role: "MAIN", Name: struct {
 						Full   string `json:"full"`
 						Native string `json:"native"`
 					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
-					{ID: 2, Role: "MAIN", Name: struct {
-						Full   string `json:"full"`
-						Native string `json:"native"`
-					}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
-					{ID: 3, Role: "SUPPORTING", Name: struct {
-						Full   string `json:"full"`
-						Native string `json:"native"`
-					}{Full: "Armin Arlert", Native: "アルミン・アルレルト"}},
-					// BACKGROUND characters should be skipped.
-					{ID: 4, Role: "BACKGROUND", Name: struct {
-						Full   string `json:"full"`
-						Native string `json:"native"`
-					}{Full: "Background NPC"}},
 				},
 			},
 		},
@@ -201,7 +170,7 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 
 	// Verify result counts:
 	// 3 season entries (Season 1, 2, 3) + 1 movie = 4 entries.
-	// 3 unique characters (Eren, Mikasa, Armin) — NOT 8.
+	// 3 unique characters (Eren, Mikasa, Armin) -- Eren deduped across seasons.
 	assert.Equal(t, 4, result.EntriesCreated)
 	assert.Equal(t, 3, result.CharactersCreated)
 
@@ -215,10 +184,14 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 	entries, err := svc.GetAnimeEntries(created.ID)
 	require.NoError(t, err)
 	var seasonCount, movieCount int
+	seasonNames := make(map[uint]string)
 	for _, e := range entries {
 		switch e.EntryType {
 		case db.EntryTypeSeason:
 			seasonCount++
+			if e.EntryNumber != nil {
+				seasonNames[*e.EntryNumber] = e.Name
+			}
 		case db.EntryTypeMovie:
 			movieCount++
 		}
@@ -226,7 +199,12 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 	assert.Equal(t, 3, seasonCount, "expected 3 season entries")
 	assert.Equal(t, 1, movieCount, "expected 1 movie entry")
 
-	// Verify character tags — only 3 unique.
+	// Verify folder names use AniList titles instead of "Season N".
+	assert.Equal(t, "Attack on Titan", seasonNames[1])
+	assert.Equal(t, "Attack on Titan Season 2", seasonNames[2])
+	assert.Equal(t, "Attack on Titan Season 3", seasonNames[3])
+
+	// Verify character tags -- only 3 unique.
 	tags, err := te.dbClient.Tag().FindTagsByAnimeID(created.ID)
 	require.NoError(t, err)
 	assert.Len(t, tags, 3)
@@ -256,32 +234,19 @@ func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 			break
 		}
 	}
+
+	// BFS makes 3 API calls (one per season).
+	assert.Equal(t, 3, mock.callCount, "BFS should make 3 API calls (one per season)")
 }
 
 func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
 	te := newTester(t)
 	ctx := context.Background()
 
+	// BFS: user selects Season 2 (ID 200). BFS discovers Season 1 via PREQUEL
+	// and Season 3 via SEQUEL, fetching each individually.
 	mock := &mockAniListClient{
 		detailResults: map[int]*anilist.MediaDetail{
-			100: {
-				ID: 100,
-				Title: anilist.MediaTitle{
-					Romaji:  "Series S1",
-					English: "Series S1",
-				},
-				Format:     "TV",
-				Season:     "WINTER",
-				SeasonYear: 2020,
-				Relations: []anilist.MediaRelation{
-					{
-						RelationType: "SEQUEL",
-						ID:           200,
-						Type:         "ANIME",
-						Format:       "TV",
-					},
-				},
-			},
 			200: {
 				ID: 200,
 				Title: anilist.MediaTitle{
@@ -295,12 +260,42 @@ func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
 					{
 						RelationType: "PREQUEL",
 						ID:           100,
-						Type:         "ANIME",
-						Format:       "TV",
+						Title: anilist.MediaTitle{
+							Romaji:  "Series S1",
+							English: "Series S1",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "WINTER",
+						SeasonYear: 2020,
 					},
 					{
 						RelationType: "SEQUEL",
 						ID:           300,
+						Title: anilist.MediaTitle{
+							Romaji:  "Series S3",
+							English: "Series S3",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "FALL",
+						SeasonYear: 2022,
+					},
+				},
+			},
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series S1",
+					English: "Series S1",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
 						Type:         "ANIME",
 						Format:       "TV",
 					},
@@ -332,8 +327,7 @@ func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
 	created, err := svc.Create(ctx, "Series Middle")
 	require.NoError(t, err)
 
-	// User selects Season 2 (middle of the chain). BFS should discover
-	// Season 1 via PREQUEL and Season 3 via SEQUEL.
+	// User selects Season 2 (middle of the chain). BFS discovers all 3.
 	result, err := svc.ImportFromAniList(ctx, created.ID, 200)
 	require.NoError(t, err)
 
@@ -342,12 +336,21 @@ func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
 	entries, err := svc.GetAnimeEntries(created.ID)
 	require.NoError(t, err)
 	seasonCount := 0
+	seasonNames := make(map[uint]string)
 	for _, e := range entries {
 		if e.EntryType == db.EntryTypeSeason {
 			seasonCount++
+			if e.EntryNumber != nil {
+				seasonNames[*e.EntryNumber] = e.Name
+			}
 		}
 	}
 	assert.Equal(t, 3, seasonCount)
+
+	// Verify folder names use AniList titles.
+	assert.Equal(t, "Series S1", seasonNames[1])
+	assert.Equal(t, "Series S2", seasonNames[2])
+	assert.Equal(t, "Series S3", seasonNames[3])
 
 	// Verify airing info: Season 1 should be 2020, Season 2 should be 2021,
 	// Season 3 should be 2022 (sorted by seasonYear).
@@ -371,6 +374,9 @@ func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
 			assert.Equal(t, uint(2022), *child.AiringYear)
 		}
 	}
+
+	// BFS makes 3 API calls (one per season).
+	assert.Equal(t, 3, mock.callCount, "BFS should make 3 API calls (one per season)")
 }
 
 func TestImportFromAniList_SkipsDuplicateEntries(t *testing.T) {
@@ -550,4 +556,403 @@ func TestSearchAniList_NilClient(t *testing.T) {
 	_, err := svc.SearchAniList(ctx, "test")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "anilist client is not configured")
+}
+
+func TestImportFromAniList_SanitizesMovieNames(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series",
+					English: "Series",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							Romaji:  "Series: The Movie",
+							English: "Series: The Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2022,
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "Series")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season + 1 movie = 2 entries.
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify the movie folder name has ":" replaced with "-".
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, "Series- The Movie", e.Name, "colon should be replaced with dash")
+			break
+		}
+	}
+}
+
+func TestParsePartSuffix(t *testing.T) {
+	tests := []struct {
+		title    string
+		wantBase string
+		wantPart int
+	}{
+		{"Attack on Titan Season 3", "Attack on Titan Season 3", 0},
+		{"Attack on Titan Season 3 Part 2", "Attack on Titan Season 3", 2},
+		{"Shingeki no Kyojin Season 3 Part 2", "Shingeki no Kyojin Season 3", 2},
+		{"The Final Season Part 3", "The Final Season", 3},
+		{"Solo Leveling", "Solo Leveling", 0},
+		{"Departures", "Departures", 0},
+		{"Part 1", "Part 1", 0}, // "Part" at start, not preceded by space
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			base, part := parsePartSuffix(tt.title)
+			assert.Equal(t, tt.wantBase, base)
+			assert.Equal(t, tt.wantPart, part)
+		})
+	}
+}
+
+func TestImportFromAniList_GroupsParts(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Mock entries:
+	// ID 100: "The Final Season" (Winter 2021) - no Part suffix
+	// ID 200: "The Final Season Part 2" (Winter 2022)
+	// ID 300: "The Final Season Part 3" (Spring 2023)
+	// All TV, connected by SEQUEL/PREQUEL.
+	//
+	// Expected:
+	// 1 season group: "The Final Season" with 3 parts (implicit Part 1, Part 2, Part 3)
+	// result.EntriesCreated = 1 (season) + 3 (parts) = 4
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season",
+					English: "The Final Season",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season Part 2",
+					English: "The Final Season Part 2",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2022,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season Part 3",
+					English: "The Final Season Part 3",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2023,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "AoT Final")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season group + 3 sub-entries (parts) = 4 entries created.
+	assert.Equal(t, 4, result.EntriesCreated)
+
+	// Verify 1 season entry with the base title.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	seasonCount := 0
+	var seasonEntry AnimeEntry
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason {
+			seasonCount++
+			seasonEntry = e
+		}
+	}
+	assert.Equal(t, 1, seasonCount, "expected 1 season group")
+	assert.Equal(t, "The Final Season", seasonEntry.Name)
+
+	// Verify 3 sub-entries under the season.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, rootFolder)
+	seasonChildren, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+
+	var seasonFileID uint
+	for _, child := range seasonChildren {
+		if child.EntryType == db.EntryTypeSeason {
+			seasonFileID = child.ID
+			break
+		}
+	}
+	require.NotZero(t, seasonFileID)
+
+	subEntries, err := te.dbClient.File().FindDirectChildDirectories(seasonFileID)
+	require.NoError(t, err)
+	assert.Len(t, subEntries, 3, "expected 3 part sub-entries")
+
+	subNames := make(map[string]bool)
+	subAiring := make(map[string]db.File) // name -> file record
+	for _, sub := range subEntries {
+		subNames[sub.Name] = true
+		subAiring[sub.Name] = sub
+	}
+	assert.True(t, subNames["Part 1"], "expected Part 1 sub-entry")
+	assert.True(t, subNames["Part 2"], "expected Part 2 sub-entry")
+	assert.True(t, subNames["Part 3"], "expected Part 3 sub-entry")
+
+	// Verify airing info on each part sub-entry.
+	// Part 1 = WINTER 2021, Part 2 = WINTER 2022, Part 3 = SPRING 2023.
+	p1 := subAiring["Part 1"]
+	assert.Equal(t, db.AiringSeasonWinter, p1.AiringSeason, "Part 1 should have WINTER season")
+	require.NotNil(t, p1.AiringYear, "Part 1 should have airing year set")
+	assert.Equal(t, uint(2021), *p1.AiringYear, "Part 1 should have year 2021")
+
+	p2 := subAiring["Part 2"]
+	assert.Equal(t, db.AiringSeasonWinter, p2.AiringSeason, "Part 2 should have WINTER season")
+	require.NotNil(t, p2.AiringYear, "Part 2 should have airing year set")
+	assert.Equal(t, uint(2022), *p2.AiringYear, "Part 2 should have year 2022")
+
+	p3 := subAiring["Part 3"]
+	assert.Equal(t, db.AiringSeasonSpring, p3.AiringSeason, "Part 3 should have SPRING season")
+	require.NotNil(t, p3.AiringYear, "Part 3 should have airing year set")
+	assert.Equal(t, uint(2023), *p3.AiringYear, "Part 3 should have year 2023")
+}
+
+func TestImportFromAniList_MixedSingleAndMultiPart(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// ID 100: "Attack on Titan" (2013) - standalone
+	// ID 200: "Attack on Titan Season 2" (2017) - standalone
+	// ID 300: "Attack on Titan Season 3" (2018) - group
+	// ID 400: "Attack on Titan Season 3 Part 2" (2019) - group
+	//
+	// Expected:
+	// 3 groups: "Attack on Titan" (1), "Attack on Titan Season 2" (1),
+	//           "Attack on Titan Season 3" (2 entries -> Part 1, Part 2)
+	// result.EntriesCreated = 3 (seasons) + 2 (parts in Season 3) = 5
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin",
+					English: "Attack on Titan",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2013,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Season 2",
+					English: "Attack on Titan Season 2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2017,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Season 3",
+					English: "Attack on Titan Season 3",
+				},
+				Format:     "TV",
+				Season:     "SUMMER",
+				SeasonYear: 2018,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           400,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			400: {
+				ID: 400,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Season 3 Part 2",
+					English: "Attack on Titan Season 3 Part 2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2019,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "AoT Mixed")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 3 season groups + 2 part sub-entries = 5 entries created.
+	assert.Equal(t, 5, result.EntriesCreated)
+
+	// Verify 3 season entries.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	seasonCount := 0
+	seasonNames := make(map[uint]string)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason {
+			seasonCount++
+			if e.EntryNumber != nil {
+				seasonNames[*e.EntryNumber] = e.Name
+			}
+		}
+	}
+	assert.Equal(t, 3, seasonCount, "expected 3 season groups")
+	assert.Equal(t, "Attack on Titan", seasonNames[1])
+	assert.Equal(t, "Attack on Titan Season 2", seasonNames[2])
+	assert.Equal(t, "Attack on Titan Season 3", seasonNames[3])
+
+	// Verify Season 3 has 2 sub-entries (Part 1, Part 2).
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, rootFolder)
+	seasonChildren, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+
+	var season3FileID uint
+	for _, child := range seasonChildren {
+		if child.EntryType == db.EntryTypeSeason && child.EntryNumber != nil && *child.EntryNumber == 3 {
+			season3FileID = child.ID
+			break
+		}
+	}
+	require.NotZero(t, season3FileID, "Season 3 entry should exist")
+
+	subEntries, err := te.dbClient.File().FindDirectChildDirectories(season3FileID)
+	require.NoError(t, err)
+	assert.Len(t, subEntries, 2, "expected 2 part sub-entries under Season 3")
+
+	subNames := make(map[string]bool)
+	for _, sub := range subEntries {
+		subNames[sub.Name] = true
+	}
+	assert.True(t, subNames["Part 1"], "expected Part 1 sub-entry")
+	assert.True(t, subNames["Part 2"], "expected Part 2 sub-entry")
+
+	// Verify Season 1 and Season 2 have no sub-entries.
+	for _, child := range seasonChildren {
+		if child.EntryType != db.EntryTypeSeason || child.EntryNumber == nil {
+			continue
+		}
+		if *child.EntryNumber == 1 || *child.EntryNumber == 2 {
+			subs, err := te.dbClient.File().FindDirectChildDirectories(child.ID)
+			require.NoError(t, err)
+			assert.Len(t, subs, 0, "Season %d should have no sub-entries", *child.EntryNumber)
+		}
+	}
 }

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -1,0 +1,344 @@
+package anime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
+	"github.com/michael-freling/anime-image-viewer/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockAniListClient implements anilist.Client for testing.
+type mockAniListClient struct {
+	searchResult []anilist.MediaSearchResult
+	searchErr    error
+	detailResult *anilist.MediaDetail
+	detailErr    error
+}
+
+func (m *mockAniListClient) SearchAnime(_ context.Context, _ string, _ int, _ int) ([]anilist.MediaSearchResult, error) {
+	return m.searchResult, m.searchErr
+}
+
+func (m *mockAniListClient) GetAnimeDetail(_ context.Context, _ int) (*anilist.MediaDetail, error) {
+	return m.detailResult, m.detailErr
+}
+
+func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResult: &anilist.MediaDetail{
+			ID: 12345,
+			Title: anilist.MediaTitle{
+				Romaji:  "Shingeki no Kyojin",
+				English: "Attack on Titan",
+			},
+			Format:     "TV",
+			Season:     "SPRING",
+			SeasonYear: 2013,
+			Relations: []anilist.MediaRelation{
+				{
+					RelationType: "SEQUEL",
+					ID:           20958,
+					Title: anilist.MediaTitle{
+						Romaji:  "Shingeki no Kyojin Season 2",
+						English: "Attack on Titan Season 2",
+					},
+					Type:       "ANIME",
+					Format:     "TV",
+					Season:     "SPRING",
+					SeasonYear: 2017,
+				},
+				{
+					RelationType: "SEQUEL",
+					ID:           99147,
+					Title: anilist.MediaTitle{
+						Romaji:  "Shingeki no Kyojin Season 3",
+						English: "Attack on Titan Season 3",
+					},
+					Type:       "ANIME",
+					Format:     "TV",
+					Season:     "SUMMER",
+					SeasonYear: 2018,
+				},
+				{
+					RelationType: "SIDE_STORY",
+					ID:           99999,
+					Title: anilist.MediaTitle{
+						Romaji:  "Shingeki no Kyojin Movie",
+						English: "Attack on Titan Movie",
+					},
+					Type:       "ANIME",
+					Format:     "MOVIE",
+					SeasonYear: 2015,
+				},
+				// This PREQUEL relation should be skipped.
+				{
+					RelationType: "PREQUEL",
+					ID:           88888,
+					Title: anilist.MediaTitle{
+						Romaji:  "Some Prequel",
+						English: "Some Prequel",
+					},
+					Type:   "ANIME",
+					Format: "TV",
+				},
+				// This MANGA relation should be skipped.
+				{
+					RelationType: "SEQUEL",
+					ID:           77777,
+					Title: anilist.MediaTitle{
+						Romaji: "Manga Version",
+					},
+					Type:   "MANGA",
+					Format: "MANGA",
+				},
+			},
+			Characters: []anilist.Character{
+				{ID: 1, Role: "MAIN", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
+				{ID: 2, Role: "MAIN", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
+				{ID: 3, Role: "SUPPORTING", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Armin Arlert", Native: "アルミン・アルレルト"}},
+				// BACKGROUND characters should be skipped.
+				{ID: 4, Role: "BACKGROUND", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Background NPC"}},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	// Create the anime first.
+	created, err := svc.Create(ctx, "Attack on Titan")
+	require.NoError(t, err)
+
+	// Run import.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	require.NoError(t, err)
+
+	// Verify result counts: season1 (main) + 2 sequels + 1 movie = 4 entries,
+	// 3 characters (MAIN + SUPPORTING only).
+	assert.Equal(t, 4, result.EntriesCreated)
+	assert.Equal(t, 3, result.CharactersCreated)
+
+	// Verify AniListID is set on the anime record.
+	animeRow, err := te.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: created.ID})
+	require.NoError(t, err)
+	require.NotNil(t, animeRow.AniListID)
+	assert.Equal(t, 12345, *animeRow.AniListID)
+
+	// Verify entries were created.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	// Count season and movie entries.
+	var seasonCount, movieCount int
+	for _, e := range entries {
+		switch e.EntryType {
+		case db.EntryTypeSeason:
+			seasonCount++
+		case db.EntryTypeMovie:
+			movieCount++
+		}
+	}
+	assert.Equal(t, 3, seasonCount, "expected 3 season entries")
+	assert.Equal(t, 1, movieCount, "expected 1 movie entry")
+
+	// Verify character tags.
+	tags, err := te.dbClient.Tag().FindTagsByAnimeID(created.ID)
+	require.NoError(t, err)
+	assert.Len(t, tags, 3)
+
+	tagNames := make(map[string]bool)
+	for _, tag := range tags {
+		tagNames[tag.Name] = true
+		assert.Equal(t, "character", tag.Category)
+		require.NotNil(t, tag.AnimeID)
+		assert.Equal(t, created.ID, *tag.AnimeID)
+	}
+	assert.True(t, tagNames["Eren Yeager"])
+	assert.True(t, tagNames["Mikasa Ackerman"])
+	assert.True(t, tagNames["Armin Arlert"])
+
+	// Verify airing info on season 1 entry.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	require.NotNil(t, rootFolder)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	// Find Season 1 entry.
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeSeason && child.EntryNumber != nil && *child.EntryNumber == 1 {
+			assert.Equal(t, db.AiringSeasonSpring, child.AiringSeason)
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2013), *child.AiringYear)
+			break
+		}
+	}
+}
+
+func TestImportFromAniList_SkipsDuplicateEntries(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResult: &anilist.MediaDetail{
+			ID: 12345,
+			Title: anilist.MediaTitle{
+				Romaji:  "Bocchi the Rock!",
+				English: "Bocchi the Rock!",
+			},
+			Format:     "TV",
+			Season:     "FALL",
+			SeasonYear: 2022,
+			Relations: []anilist.MediaRelation{
+				{
+					RelationType: "SEQUEL",
+					ID:           200000,
+					Title: anilist.MediaTitle{
+						Romaji:  "Bocchi the Rock! Season 2",
+						English: "Bocchi the Rock! Season 2",
+					},
+					Type:       "ANIME",
+					Format:     "TV",
+					Season:     "SPRING",
+					SeasonYear: 2025,
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	// Create the anime.
+	created, err := svc.Create(ctx, "Bocchi the Rock!")
+	require.NoError(t, err)
+
+	// Pre-create Season 1 manually.
+	_, err = svc.CreateEntry(ctx, created.ID, db.EntryTypeSeason, nil, "")
+	require.NoError(t, err)
+
+	// Run import. Season 1 already exists, so only Season 2 should be created,
+	// plus no characters.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	require.NoError(t, err)
+
+	// ensureSeasonEntry creates the next number, so Season 1 exists and import
+	// creates Season 2 for the main anime + Season 3 for the sequel = 2 entries.
+	// Actually: the main anime triggers ensureSeasonEntry which gets Season 2
+	// (since Season 1 exists). The sequel triggers another ensureSeasonEntry
+	// which gets Season 3.
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify total season entries: Season 1 (manual) + Season 2 (main) + Season 3 (sequel).
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	seasonCount := 0
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason {
+			seasonCount++
+		}
+	}
+	assert.Equal(t, 3, seasonCount)
+}
+
+func TestImportFromAniList_SkipsDuplicateCharacters(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResult: &anilist.MediaDetail{
+			ID: 12345,
+			Title: anilist.MediaTitle{
+				Romaji:  "Frieren",
+				English: "Frieren",
+			},
+			Format:     "TV",
+			Season:     "FALL",
+			SeasonYear: 2023,
+			Characters: []anilist.Character{
+				{ID: 1, Role: "MAIN", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Frieren"}},
+				{ID: 2, Role: "MAIN", Name: struct {
+					Full   string `json:"full"`
+					Native string `json:"native"`
+				}{Full: "Fern"}},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	// Create the anime.
+	created, err := svc.Create(ctx, "Frieren")
+	require.NoError(t, err)
+
+	// Pre-create a character tag for "Frieren".
+	aid := created.ID
+	preTag := db.Tag{Name: "Frieren", Category: "character", AnimeID: &aid}
+	require.NoError(t, te.dbClient.Tag().Create(ctx, &preTag))
+
+	// Run import.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	require.NoError(t, err)
+
+	// Only "Fern" should be created; "Frieren" already exists.
+	assert.Equal(t, 1, result.CharactersCreated)
+
+	// Verify total character tags.
+	tags, err := te.dbClient.Tag().FindTagsByAnimeID(created.ID)
+	require.NoError(t, err)
+	assert.Len(t, tags, 2)
+}
+
+func TestSearchAniList(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	expected := []anilist.MediaSearchResult{
+		{
+			ID: 1,
+			Title: anilist.MediaTitle{
+				Romaji:  "Shingeki no Kyojin",
+				English: "Attack on Titan",
+			},
+			Format: "TV",
+		},
+	}
+
+	mock := &mockAniListClient{
+		searchResult: expected,
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	results, err := svc.SearchAniList(ctx, "attack on titan")
+	require.NoError(t, err)
+	assert.Equal(t, expected, results)
+}
+
+func TestSearchAniList_NilClient(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	svc := te.service() // nil anilist client
+
+	_, err := svc.SearchAniList(ctx, "test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anilist client is not configured")
+}

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -2,6 +2,7 @@ package anime
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/michael-freling/anime-image-viewer/internal/anilist"
@@ -953,6 +954,713 @@ func TestImportFromAniList_MixedSingleAndMultiPart(t *testing.T) {
 			subs, err := te.dbClient.File().FindDirectChildDirectories(child.ID)
 			require.NoError(t, err)
 			assert.Len(t, subs, 0, "Season %d should have no sub-entries", *child.EntryNumber)
+		}
+	}
+}
+
+func TestLinkAniList(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{}
+
+	t.Run("sets AniListID on existing anime", func(t *testing.T) {
+		svc := te.serviceWithAniList(mock)
+		created, err := svc.Create(ctx, "LinkTest")
+		require.NoError(t, err)
+
+		err = svc.LinkAniList(ctx, created.ID, 42)
+		require.NoError(t, err)
+
+		row, err := te.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: created.ID})
+		require.NoError(t, err)
+		require.NotNil(t, row.AniListID)
+		assert.Equal(t, 42, *row.AniListID)
+	})
+
+	t.Run("nil client returns error", func(t *testing.T) {
+		svc := te.service() // no anilist client
+		err := svc.LinkAniList(ctx, 1, 42)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "anilist client is not configured")
+	})
+
+	t.Run("nonexistent anime returns error", func(t *testing.T) {
+		svc := te.serviceWithAniList(mock)
+		err := svc.LinkAniList(ctx, 99999, 42)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrAnimeNotFound)
+	})
+}
+
+func TestDetailDisplayName(t *testing.T) {
+	t.Run("prefers English title", func(t *testing.T) {
+		d := &anilist.MediaDetail{
+			Title: anilist.MediaTitle{
+				English: "Attack on Titan",
+				Romaji:  "Shingeki no Kyojin",
+			},
+		}
+		assert.Equal(t, "Attack on Titan", detailDisplayName(d))
+	})
+
+	t.Run("falls back to Romaji when English is empty", func(t *testing.T) {
+		d := &anilist.MediaDetail{
+			Title: anilist.MediaTitle{
+				English: "",
+				Romaji:  "Shingeki no Kyojin",
+			},
+		}
+		assert.Equal(t, "Shingeki no Kyojin", detailDisplayName(d))
+	})
+}
+
+func TestRelationDisplayName(t *testing.T) {
+	t.Run("prefers English title", func(t *testing.T) {
+		r := anilist.MediaRelation{
+			Title: anilist.MediaTitle{
+				English: "The Movie",
+				Romaji:  "Gekijouban",
+			},
+		}
+		assert.Equal(t, "The Movie", relationDisplayName(r))
+	})
+
+	t.Run("falls back to Romaji when English is empty", func(t *testing.T) {
+		r := anilist.MediaRelation{
+			Title: anilist.MediaTitle{
+				English: "",
+				Romaji:  "Gekijouban",
+			},
+		}
+		assert.Equal(t, "Gekijouban", relationDisplayName(r))
+	})
+}
+
+func TestImportFromAniList_GetAnimeDetailError(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailErr: fmt.Errorf("api timeout"),
+	}
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "DetailError")
+	require.NoError(t, err)
+
+	_, err = svc.ImportFromAniList(ctx, created.ID, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anilist.GetAnimeDetail(100)")
+	assert.Contains(t, err.Error(), "api timeout")
+}
+
+func TestImportFromAniList_DetailReturnsNil(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Return nil for the detail -- BFS skips it.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{},
+	}
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "NilDetail")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.EntriesCreated)
+	assert.Equal(t, 0, result.CharactersCreated)
+}
+
+func TestImportFromAniList_SkipsNonAnimeRelations(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// A season with a MANGA relation, MUSIC relation, and a SEQUEL OVA that is
+	// not TV/ONA format. None of these should be followed by BFS.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "Test Show",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "MANGA",
+						Format:       "MANGA",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "MUSIC",
+					},
+					{
+						RelationType: "CHARACTER",
+						ID:           400,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "SkipRelations")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// Only 1 season (the root), no sequel followed.
+	assert.Equal(t, 1, result.EntriesCreated)
+	assert.Equal(t, 1, mock.callCount, "BFS should only fetch the root entry")
+}
+
+func TestImportFromAniList_MovieWithParentRelation(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// A season with a PARENT relation that is a movie.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "ParentMovieShow",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PARENT",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "The Parent Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2022,
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "ParentMovieTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season + 1 movie = 2
+	assert.Equal(t, 2, result.EntriesCreated)
+}
+
+func TestImportFromAniList_SkipsBackgroundCharacters(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "CharFilter",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2020,
+				Characters: []anilist.Character{
+					{ID: 1, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Hero"}},
+					{ID: 2, Role: "BACKGROUND", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Extra"}},
+					{ID: 3, Role: "SUPPORTING", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: ""}}, // empty name, should be skipped
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "CharFilterTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// Only "Hero" should be created. "Extra" is BACKGROUND (skipped), empty name is skipped.
+	assert.Equal(t, 1, result.CharactersCreated)
+}
+
+func TestImportFromAniList_FollowsONAFormat(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// BFS should follow ONA format relations (isSeasonFormat includes ONA).
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "ONA Show S1",
+				},
+				Format:     "ONA",
+				Season:     "WINTER",
+				SeasonYear: 2023,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "ONA",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					English: "ONA Show S2",
+				},
+				Format:     "ONA",
+				Season:     "SUMMER",
+				SeasonYear: 2024,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "ONA",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "ONATest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 2 seasons created from ONA entries.
+	assert.Equal(t, 2, result.EntriesCreated)
+	assert.Equal(t, 2, mock.callCount)
+}
+
+func TestImportFromAniList_MovieWithZeroYear(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Movie relation with SeasonYear 0 -- year should be nil.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "YearlessShow",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "Yearless Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 0,
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "YearlessTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season + 1 movie = 2
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify the movie has nil year.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeMovie {
+			assert.Nil(t, e.EntryNumber, "movie with zero year should have nil entry_number")
+		}
+	}
+}
+
+func TestImportFromAniList_BFSDeduplication(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// BFS dedup scenario: IDs 100 and 200 both have SEQUEL pointing to 300.
+	// 100 is processed first, adding 200 and 300 to queue. Then 200 is processed,
+	// adding 300 again (since 300 is not yet fetched). Queue becomes [300, 300].
+	// The second 300 should be deduplicated by the fetched check.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "Show S1",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					English: "Show S2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					English: "Show S3",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2022,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "BFSDedupTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.EntriesCreated)
+	// BFS should make exactly 3 calls, even though 300 was discovered twice.
+	assert.Equal(t, 3, mock.callCount)
+}
+
+func TestImportFromAniList_SameYearSortsById(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Two seasons in the same year -- should be sorted by AniList ID as tiebreaker.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					English: "Same Year S2",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2023,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "Same Year S1",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2023,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "SameYearSort")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify season order: S1 (ID 100) should be Season 1, S2 (ID 300) should be Season 2
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	seasonNames := make(map[uint]string)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason && e.EntryNumber != nil {
+			seasonNames[*e.EntryNumber] = e.Name
+		}
+	}
+	assert.Equal(t, "Same Year S1", seasonNames[1])
+	assert.Equal(t, "Same Year S2", seasonNames[2])
+}
+
+func TestImportFromAniList_DuplicateMovieDedup(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Two seasons both reference the same movie. Movie should only be created once.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					English: "MovieDedup S1",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "The Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2021,
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					English: "MovieDedup S2",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							English: "The Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2021,
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "MovieDedupTest")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 2 seasons + 1 movie (deduped) = 3
+	assert.Equal(t, 3, result.EntriesCreated)
+
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	movieCount := 0
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeMovie {
+			movieCount++
+		}
+	}
+	assert.Equal(t, 1, movieCount, "duplicate movie should be deduped")
+}
+
+func TestImportFromAniList_NilClient(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	svc := te.service() // nil anilist client
+
+	created, err := svc.Create(ctx, "NilClientImport")
+	require.NoError(t, err)
+
+	_, err = svc.ImportFromAniList(ctx, created.ID, 100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anilist client is not configured")
+}
+
+func TestImportFromAniList_NonexistentAnime(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID:     100,
+				Title:  anilist.MediaTitle{Romaji: "Test"},
+				Format: "TV",
+			},
+		},
+	}
+	svc := te.serviceWithAniList(mock)
+
+	_, err := svc.ImportFromAniList(ctx, 99999, 100)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAnimeNotFound)
+}
+
+func TestAnilistSeasonToDBSeason(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"WINTER", db.AiringSeasonWinter},
+		{"SPRING", db.AiringSeasonSpring},
+		{"SUMMER", db.AiringSeasonSummer},
+		{"FALL", db.AiringSeasonFall},
+		{"", ""},
+		{"UNKNOWN", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, anilistSeasonToDBSeason(tt.input))
+		})
+	}
+}
+
+func TestImportFromAniList_RomajiOnlyTitles(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Entries with only Romaji titles (no English) to cover the Romaji fallback
+	// paths in detailDisplayName and relationDisplayName.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji: "Shingeki no Kyojin",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2013,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SIDE_STORY",
+						ID:           999,
+						Title: anilist.MediaTitle{
+							Romaji: "Shingeki no Kyojin Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2015,
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "RomajiOnly")
+	require.NoError(t, err)
+
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+
+	// 1 season + 1 movie = 2
+	assert.Equal(t, 2, result.EntriesCreated)
+
+	// Verify the season name uses Romaji.
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason {
+			assert.Equal(t, "Shingeki no Kyojin", e.Name)
+		}
+		if e.EntryType == db.EntryTypeMovie {
+			assert.Equal(t, "Shingeki no Kyojin Movie", e.Name)
 		}
 	}
 }

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -12,110 +12,179 @@ import (
 
 // mockAniListClient implements anilist.Client for testing.
 type mockAniListClient struct {
-	searchResult []anilist.MediaSearchResult
-	searchErr    error
-	detailResult *anilist.MediaDetail
-	detailErr    error
+	searchResult  []anilist.MediaSearchResult
+	searchErr     error
+	detailResults map[int]*anilist.MediaDetail // keyed by AniList ID
+	detailErr     error
 }
 
 func (m *mockAniListClient) SearchAnime(_ context.Context, _ string, _ int, _ int) ([]anilist.MediaSearchResult, error) {
 	return m.searchResult, m.searchErr
 }
 
-func (m *mockAniListClient) GetAnimeDetail(_ context.Context, _ int) (*anilist.MediaDetail, error) {
-	return m.detailResult, m.detailErr
+func (m *mockAniListClient) GetAnimeDetail(_ context.Context, id int) (*anilist.MediaDetail, error) {
+	if m.detailErr != nil {
+		return nil, m.detailErr
+	}
+	return m.detailResults[id], nil
 }
 
-func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
+func TestImportFromAniList_FollowsChainAndDeduplicatesCharacters(t *testing.T) {
 	te := newTester(t)
 	ctx := context.Background()
 
 	mock := &mockAniListClient{
-		detailResult: &anilist.MediaDetail{
-			ID: 12345,
-			Title: anilist.MediaTitle{
-				Romaji:  "Shingeki no Kyojin",
-				English: "Attack on Titan",
-			},
-			Format:     "TV",
-			Season:     "SPRING",
-			SeasonYear: 2013,
-			Relations: []anilist.MediaRelation{
-				{
-					RelationType: "SEQUEL",
-					ID:           20958,
-					Title: anilist.MediaTitle{
-						Romaji:  "Shingeki no Kyojin Season 2",
-						English: "Attack on Titan Season 2",
-					},
-					Type:       "ANIME",
-					Format:     "TV",
-					Season:     "SPRING",
-					SeasonYear: 2017,
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin",
+					English: "Attack on Titan",
 				},
-				{
-					RelationType: "SEQUEL",
-					ID:           99147,
-					Title: anilist.MediaTitle{
-						Romaji:  "Shingeki no Kyojin Season 3",
-						English: "Attack on Titan Season 3",
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2013,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Title: anilist.MediaTitle{
+							Romaji:  "Shingeki no Kyojin Season 2",
+							English: "Attack on Titan Season 2",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "SPRING",
+						SeasonYear: 2017,
 					},
-					Type:       "ANIME",
-					Format:     "TV",
-					Season:     "SUMMER",
-					SeasonYear: 2018,
+					// MANGA relation should be skipped.
+					{
+						RelationType: "SEQUEL",
+						ID:           77777,
+						Title: anilist.MediaTitle{
+							Romaji: "Manga Version",
+						},
+						Type:   "MANGA",
+						Format: "MANGA",
+					},
 				},
-				{
-					RelationType: "SIDE_STORY",
-					ID:           99999,
-					Title: anilist.MediaTitle{
-						Romaji:  "Shingeki no Kyojin Movie",
-						English: "Attack on Titan Movie",
-					},
-					Type:       "ANIME",
-					Format:     "MOVIE",
-					SeasonYear: 2015,
-				},
-				// This PREQUEL relation should be skipped.
-				{
-					RelationType: "PREQUEL",
-					ID:           88888,
-					Title: anilist.MediaTitle{
-						Romaji:  "Some Prequel",
-						English: "Some Prequel",
-					},
-					Type:   "ANIME",
-					Format: "TV",
-				},
-				// This MANGA relation should be skipped.
-				{
-					RelationType: "SEQUEL",
-					ID:           77777,
-					Title: anilist.MediaTitle{
-						Romaji: "Manga Version",
-					},
-					Type:   "MANGA",
-					Format: "MANGA",
+				Characters: []anilist.Character{
+					{ID: 1, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
+					{ID: 2, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
 				},
 			},
-			Characters: []anilist.Character{
-				{ID: 1, Role: "MAIN", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
-				{ID: 2, Role: "MAIN", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
-				{ID: 3, Role: "SUPPORTING", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Armin Arlert", Native: "アルミン・アルレルト"}},
-				// BACKGROUND characters should be skipped.
-				{ID: 4, Role: "BACKGROUND", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Background NPC"}},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Season 2",
+					English: "Attack on Titan Season 2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2017,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Title: anilist.MediaTitle{
+							Romaji:  "Shingeki no Kyojin",
+							English: "Attack on Titan",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "SPRING",
+						SeasonYear: 2013,
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Title: anilist.MediaTitle{
+							Romaji:  "Shingeki no Kyojin Season 3",
+							English: "Attack on Titan Season 3",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "SUMMER",
+						SeasonYear: 2018,
+					},
+					{
+						RelationType: "SIDE_STORY",
+						ID:           99999,
+						Title: anilist.MediaTitle{
+							Romaji:  "Shingeki no Kyojin Movie",
+							English: "Attack on Titan Movie",
+						},
+						Type:       "ANIME",
+						Format:     "MOVIE",
+						SeasonYear: 2015,
+					},
+				},
+				Characters: []anilist.Character{
+					// Duplicates of Season 1 characters.
+					{ID: 1, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
+					{ID: 2, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
+					// New character in Season 2.
+					{ID: 3, Role: "SUPPORTING", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Armin Arlert", Native: "アルミン・アルレルト"}},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin Season 3",
+					English: "Attack on Titan Season 3",
+				},
+				Format:     "TV",
+				Season:     "SUMMER",
+				SeasonYear: 2018,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Title: anilist.MediaTitle{
+							Romaji:  "Shingeki no Kyojin Season 2",
+							English: "Attack on Titan Season 2",
+						},
+						Type:       "ANIME",
+						Format:     "TV",
+						Season:     "SPRING",
+						SeasonYear: 2017,
+					},
+				},
+				Characters: []anilist.Character{
+					// All duplicates.
+					{ID: 1, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Eren Yeager", Native: "エレン・イェーガー"}},
+					{ID: 2, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Mikasa Ackerman", Native: "ミカサ・アッカーマン"}},
+					{ID: 3, Role: "SUPPORTING", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Armin Arlert", Native: "アルミン・アルレルト"}},
+					// BACKGROUND characters should be skipped.
+					{ID: 4, Role: "BACKGROUND", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Background NPC"}},
+				},
 			},
 		},
 	}
@@ -126,12 +195,13 @@ func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
 	created, err := svc.Create(ctx, "Attack on Titan")
 	require.NoError(t, err)
 
-	// Run import.
-	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	// Run import starting from Season 1.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
 	require.NoError(t, err)
 
-	// Verify result counts: season1 (main) + 2 sequels + 1 movie = 4 entries,
-	// 3 characters (MAIN + SUPPORTING only).
+	// Verify result counts:
+	// 3 season entries (Season 1, 2, 3) + 1 movie = 4 entries.
+	// 3 unique characters (Eren, Mikasa, Armin) — NOT 8.
 	assert.Equal(t, 4, result.EntriesCreated)
 	assert.Equal(t, 3, result.CharactersCreated)
 
@@ -139,12 +209,11 @@ func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
 	animeRow, err := te.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: created.ID})
 	require.NoError(t, err)
 	require.NotNil(t, animeRow.AniListID)
-	assert.Equal(t, 12345, *animeRow.AniListID)
+	assert.Equal(t, 100, *animeRow.AniListID)
 
 	// Verify entries were created.
 	entries, err := svc.GetAnimeEntries(created.ID)
 	require.NoError(t, err)
-	// Count season and movie entries.
 	var seasonCount, movieCount int
 	for _, e := range entries {
 		switch e.EntryType {
@@ -157,7 +226,7 @@ func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
 	assert.Equal(t, 3, seasonCount, "expected 3 season entries")
 	assert.Equal(t, 1, movieCount, "expected 1 movie entry")
 
-	// Verify character tags.
+	// Verify character tags — only 3 unique.
 	tags, err := te.dbClient.Tag().FindTagsByAnimeID(created.ID)
 	require.NoError(t, err)
 	assert.Len(t, tags, 3)
@@ -179,7 +248,6 @@ func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
 	require.NotNil(t, rootFolder)
 	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
 	require.NoError(t, err)
-	// Find Season 1 entry.
 	for _, child := range children {
 		if child.EntryType == db.EntryTypeSeason && child.EntryNumber != nil && *child.EntryNumber == 1 {
 			assert.Equal(t, db.AiringSeasonSpring, child.AiringSeason)
@@ -190,32 +258,163 @@ func TestImportFromAniList_CreatesEntriesAndCharacters(t *testing.T) {
 	}
 }
 
+func TestImportFromAniList_SelectMiddleSeason(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series S1",
+					English: "Series S1",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2020,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series S2",
+					English: "Series S2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					Romaji:  "Series S3",
+					English: "Series S3",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2022,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+
+	created, err := svc.Create(ctx, "Series Middle")
+	require.NoError(t, err)
+
+	// User selects Season 2 (middle of the chain). BFS should discover
+	// Season 1 via PREQUEL and Season 3 via SEQUEL.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 200)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, result.EntriesCreated, "all 3 seasons should be created")
+
+	entries, err := svc.GetAnimeEntries(created.ID)
+	require.NoError(t, err)
+	seasonCount := 0
+	for _, e := range entries {
+		if e.EntryType == db.EntryTypeSeason {
+			seasonCount++
+		}
+	}
+	assert.Equal(t, 3, seasonCount)
+
+	// Verify airing info: Season 1 should be 2020, Season 2 should be 2021,
+	// Season 3 should be 2022 (sorted by seasonYear).
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType != db.EntryTypeSeason || child.EntryNumber == nil {
+			continue
+		}
+		switch *child.EntryNumber {
+		case 1:
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2020), *child.AiringYear)
+		case 2:
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2021), *child.AiringYear)
+		case 3:
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2022), *child.AiringYear)
+		}
+	}
+}
+
 func TestImportFromAniList_SkipsDuplicateEntries(t *testing.T) {
 	te := newTester(t)
 	ctx := context.Background()
 
 	mock := &mockAniListClient{
-		detailResult: &anilist.MediaDetail{
-			ID: 12345,
-			Title: anilist.MediaTitle{
-				Romaji:  "Bocchi the Rock!",
-				English: "Bocchi the Rock!",
-			},
-			Format:     "TV",
-			Season:     "FALL",
-			SeasonYear: 2022,
-			Relations: []anilist.MediaRelation{
-				{
-					RelationType: "SEQUEL",
-					ID:           200000,
-					Title: anilist.MediaTitle{
-						Romaji:  "Bocchi the Rock! Season 2",
-						English: "Bocchi the Rock! Season 2",
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Bocchi the Rock!",
+					English: "Bocchi the Rock!",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2022,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+						Season:       "SPRING",
+						SeasonYear:   2025,
 					},
-					Type:       "ANIME",
-					Format:     "TV",
-					Season:     "SPRING",
-					SeasonYear: 2025,
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Bocchi the Rock! Season 2",
+					English: "Bocchi the Rock! Season 2",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2025,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
 				},
 			},
 		},
@@ -231,19 +430,13 @@ func TestImportFromAniList_SkipsDuplicateEntries(t *testing.T) {
 	_, err = svc.CreateEntry(ctx, created.ID, db.EntryTypeSeason, nil, "")
 	require.NoError(t, err)
 
-	// Run import. Season 1 already exists, so only Season 2 should be created,
-	// plus no characters.
-	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	// Run import. Season 1 already exists, so only Season 2 should be created.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
 	require.NoError(t, err)
 
-	// ensureSeasonEntry creates the next number, so Season 1 exists and import
-	// creates Season 2 for the main anime + Season 3 for the sequel = 2 entries.
-	// Actually: the main anime triggers ensureSeasonEntry which gets Season 2
-	// (since Season 1 exists). The sequel triggers another ensureSeasonEntry
-	// which gets Season 3.
-	assert.Equal(t, 2, result.EntriesCreated)
+	assert.Equal(t, 1, result.EntriesCreated, "only Season 2 should be newly created")
 
-	// Verify total season entries: Season 1 (manual) + Season 2 (main) + Season 3 (sequel).
+	// Verify total season entries: Season 1 (pre-existing) + Season 2 (new).
 	entries, err := svc.GetAnimeEntries(created.ID)
 	require.NoError(t, err)
 	seasonCount := 0
@@ -252,7 +445,21 @@ func TestImportFromAniList_SkipsDuplicateEntries(t *testing.T) {
 			seasonCount++
 		}
 	}
-	assert.Equal(t, 3, seasonCount)
+	assert.Equal(t, 2, seasonCount)
+
+	// Verify Season 1 has updated airing info.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	children, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range children {
+		if child.EntryType == db.EntryTypeSeason && child.EntryNumber != nil && *child.EntryNumber == 1 {
+			assert.Equal(t, db.AiringSeasonFall, child.AiringSeason)
+			require.NotNil(t, child.AiringYear)
+			assert.Equal(t, uint(2022), *child.AiringYear)
+			break
+		}
+	}
 }
 
 func TestImportFromAniList_SkipsDuplicateCharacters(t *testing.T) {
@@ -260,24 +467,26 @@ func TestImportFromAniList_SkipsDuplicateCharacters(t *testing.T) {
 	ctx := context.Background()
 
 	mock := &mockAniListClient{
-		detailResult: &anilist.MediaDetail{
-			ID: 12345,
-			Title: anilist.MediaTitle{
-				Romaji:  "Frieren",
-				English: "Frieren",
-			},
-			Format:     "TV",
-			Season:     "FALL",
-			SeasonYear: 2023,
-			Characters: []anilist.Character{
-				{ID: 1, Role: "MAIN", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Frieren"}},
-				{ID: 2, Role: "MAIN", Name: struct {
-					Full   string `json:"full"`
-					Native string `json:"native"`
-				}{Full: "Fern"}},
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Frieren",
+					English: "Frieren",
+				},
+				Format:     "TV",
+				Season:     "FALL",
+				SeasonYear: 2023,
+				Characters: []anilist.Character{
+					{ID: 1, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Frieren"}},
+					{ID: 2, Role: "MAIN", Name: struct {
+						Full   string `json:"full"`
+						Native string `json:"native"`
+					}{Full: "Fern"}},
+				},
 			},
 		},
 	}
@@ -294,7 +503,7 @@ func TestImportFromAniList_SkipsDuplicateCharacters(t *testing.T) {
 	require.NoError(t, te.dbClient.Tag().Create(ctx, &preTag))
 
 	// Run import.
-	result, err := svc.ImportFromAniList(ctx, created.ID, 12345)
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
 	require.NoError(t, err)
 
 	// Only "Fern" should be created; "Frieren" already exists.

--- a/internal/anime/anilist_import_test.go
+++ b/internal/anime/anilist_import_test.go
@@ -1664,3 +1664,178 @@ func TestImportFromAniList_RomajiOnlyTitles(t *testing.T) {
 		}
 	}
 }
+
+func TestImportFromAniList_ReimportUpdatesExistingSubEntryAiringInfo(t *testing.T) {
+	te := newTester(t)
+	ctx := context.Background()
+
+	// Multi-part group: "The Final Season" with Part 1, Part 2, Part 3.
+	// First import creates everything. Second import (re-import) should update
+	// airing info on existing sub-entries even though the parent season and
+	// sub-entries already exist.
+	mock := &mockAniListClient{
+		detailResults: map[int]*anilist.MediaDetail{
+			100: {
+				ID: 100,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season",
+					English: "The Final Season",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2021,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "SEQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+					{
+						RelationType: "SEQUEL",
+						ID:           300,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			200: {
+				ID: 200,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season Part 2",
+					English: "The Final Season Part 2",
+				},
+				Format:     "TV",
+				Season:     "WINTER",
+				SeasonYear: 2022,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           100,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+			300: {
+				ID: 300,
+				Title: anilist.MediaTitle{
+					Romaji:  "Shingeki no Kyojin: The Final Season Part 3",
+					English: "The Final Season Part 3",
+				},
+				Format:     "TV",
+				Season:     "SPRING",
+				SeasonYear: 2023,
+				Relations: []anilist.MediaRelation{
+					{
+						RelationType: "PREQUEL",
+						ID:           200,
+						Type:         "ANIME",
+						Format:       "TV",
+					},
+				},
+			},
+		},
+	}
+
+	svc := te.serviceWithAniList(mock)
+	created, err := svc.Create(ctx, "AoT Reimport")
+	require.NoError(t, err)
+
+	// First import: creates season + 3 parts = 4 entries.
+	result, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.EntriesCreated, "first import should create 4 entries")
+
+	// Verify sub-entries have airing info after first import.
+	rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+	require.NoError(t, err)
+	seasonChildren, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+
+	var seasonFileID uint
+	for _, child := range seasonChildren {
+		if child.EntryType == db.EntryTypeSeason {
+			seasonFileID = child.ID
+			break
+		}
+	}
+	require.NotZero(t, seasonFileID)
+
+	subEntries, err := te.dbClient.File().FindDirectChildDirectories(seasonFileID)
+	require.NoError(t, err)
+	require.Len(t, subEntries, 3, "expected 3 sub-entries after first import")
+
+	// Verify initial airing info is set.
+	for _, sub := range subEntries {
+		switch sub.Name {
+		case "Part 1":
+			assert.Equal(t, db.AiringSeasonWinter, sub.AiringSeason)
+			require.NotNil(t, sub.AiringYear)
+			assert.Equal(t, uint(2021), *sub.AiringYear)
+		case "Part 2":
+			assert.Equal(t, db.AiringSeasonWinter, sub.AiringSeason)
+			require.NotNil(t, sub.AiringYear)
+			assert.Equal(t, uint(2022), *sub.AiringYear)
+		case "Part 3":
+			assert.Equal(t, db.AiringSeasonSpring, sub.AiringSeason)
+			require.NotNil(t, sub.AiringYear)
+			assert.Equal(t, uint(2023), *sub.AiringYear)
+		}
+	}
+
+	// Now update the mock to have different airing info (simulating AniList
+	// data correction or new info becoming available).
+	mock.detailResults[100].Season = "FALL"
+	mock.detailResults[100].SeasonYear = 2020
+	mock.detailResults[200].Season = "SUMMER"
+	mock.detailResults[200].SeasonYear = 2021
+	mock.detailResults[300].Season = "FALL"
+	mock.detailResults[300].SeasonYear = 2023
+
+	// Second import (re-import): nothing new created, but airing info updated.
+	result2, err := svc.ImportFromAniList(ctx, created.ID, 100)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result2.EntriesCreated, "re-import should not create new entries")
+
+	// Verify sub-entries now have the updated airing info.
+	subEntries2, err := te.dbClient.File().FindDirectChildDirectories(seasonFileID)
+	require.NoError(t, err)
+	require.Len(t, subEntries2, 3, "should still have 3 sub-entries")
+
+	subAiring := make(map[string]db.File)
+	for _, sub := range subEntries2 {
+		subAiring[sub.Name] = sub
+	}
+
+	// Part 1: FALL 2020 (was WINTER 2021)
+	p1 := subAiring["Part 1"]
+	assert.Equal(t, db.AiringSeasonFall, p1.AiringSeason, "Part 1 should have updated FALL season")
+	require.NotNil(t, p1.AiringYear, "Part 1 should have airing year set")
+	assert.Equal(t, uint(2020), *p1.AiringYear, "Part 1 should have updated year 2020")
+
+	// Part 2: SUMMER 2021 (was WINTER 2022)
+	p2 := subAiring["Part 2"]
+	assert.Equal(t, db.AiringSeasonSummer, p2.AiringSeason, "Part 2 should have updated SUMMER season")
+	require.NotNil(t, p2.AiringYear, "Part 2 should have airing year set")
+	assert.Equal(t, uint(2021), *p2.AiringYear, "Part 2 should have updated year 2021")
+
+	// Part 3: FALL 2023 (was SPRING 2023)
+	p3 := subAiring["Part 3"]
+	assert.Equal(t, db.AiringSeasonFall, p3.AiringSeason, "Part 3 should have updated FALL season")
+	require.NotNil(t, p3.AiringYear, "Part 3 should have airing year set")
+	assert.Equal(t, uint(2023), *p3.AiringYear, "Part 3 should have year 2023")
+
+	// Also verify the parent season entry got updated airing info.
+	// The parent uses the first part's info (Part 1 = FALL 2020).
+	seasonChildren2, err := te.dbClient.File().FindDirectChildDirectories(rootFolder.ID)
+	require.NoError(t, err)
+	for _, child := range seasonChildren2 {
+		if child.EntryType == db.EntryTypeSeason && child.ID == seasonFileID {
+			assert.Equal(t, db.AiringSeasonFall, child.AiringSeason, "parent season should have updated FALL season")
+			require.NotNil(t, child.AiringYear, "parent season should have airing year set")
+			assert.Equal(t, uint(2020), *child.AiringYear, "parent season should have updated year 2020")
+			break
+		}
+	}
+}

--- a/internal/anime/main_test.go
+++ b/internal/anime/main_test.go
@@ -3,6 +3,7 @@ package anime
 import (
 	"testing"
 
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
@@ -31,5 +32,9 @@ func (te tester) directoryReader() *image.DirectoryReader {
 }
 
 func (te tester) service() *Service {
-	return NewService(te.dbClient.Client, te.directoryReader(), te.config)
+	return NewService(te.dbClient.Client, te.directoryReader(), te.config, nil)
+}
+
+func (te tester) serviceWithAniList(client anilist.Client) *Service {
+	return NewService(te.dbClient.Client, te.directoryReader(), te.config, client)
 }

--- a/internal/anime/service.go
+++ b/internal/anime/service.go
@@ -19,19 +19,6 @@ import (
 
 var invalidFolderChars = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1f]`)
 
-func validateFolderName(name string) error {
-	if name == "" {
-		return fmt.Errorf("name cannot be empty")
-	}
-	if invalidFolderChars.MatchString(name) {
-		return fmt.Errorf("name contains invalid characters")
-	}
-	if name == "." || name == ".." {
-		return fmt.Errorf("name cannot be a dot or double dot")
-	}
-	return nil
-}
-
 // Service exposes anime CRUD plus tag and folder assignment logic. It is the
 // core anime business layer; the frontend.AnimeService is a thin Wails
 // adapter on top of it.
@@ -61,11 +48,12 @@ func (s *Service) Create(ctx context.Context, name string) (Anime, error) {
 		return Anime{}, fmt.Errorf("%w: name is required", xerrors.ErrInvalidArgument)
 	}
 
-	dirPath := filepath.Join(s.config.ImageRootDirectory, name)
+	folderName := sanitizeFolderName(name)
+	dirPath := filepath.Join(s.config.ImageRootDirectory, folderName)
 
 	var row db.Anime
 	err := db.NewTransaction(ctx, s.dbClient, func(ctx context.Context) error {
-		// 1. Create the anime DB row
+		// 1. Create the anime DB row (display name keeps original)
 		row = db.Anime{Name: name}
 		if err := s.dbClient.Anime().Create(ctx, &row); err != nil {
 			if isUniqueViolation(err) {
@@ -74,10 +62,10 @@ func (s *Service) Create(ctx context.Context, name string) (Anime, error) {
 			return err
 		}
 
-		// 2. Create the db.File record for the folder
+		// 2. Create the db.File record for the folder (sanitized for disk)
 		animeID := row.ID
 		dirFile := db.File{
-			Name:     name,
+			Name:     folderName,
 			ParentID: db.RootDirectoryID,
 			Type:     db.FileTypeDirectory,
 			AnimeID:  &animeID,
@@ -114,6 +102,8 @@ func (s *Service) Rename(ctx context.Context, id uint, name string) (Anime, erro
 		return Anime{}, fmt.Errorf("%w: name is required", xerrors.ErrInvalidArgument)
 	}
 
+	folderName := sanitizeFolderName(name)
+
 	var updated db.Anime
 	err := db.NewTransaction(ctx, s.dbClient, func(ctx context.Context) error {
 		client := s.dbClient.Anime()
@@ -124,8 +114,7 @@ func (s *Service) Rename(ctx context.Context, id uint, name string) (Anime, erro
 		if err != nil {
 			return err
 		}
-		oldName := row.Name
-		row.Name = name
+		row.Name = name // display name keeps original
 		if err := client.Update(ctx, &row); err != nil {
 			if isUniqueViolation(err) {
 				return fmt.Errorf("%w: %s", ErrAnimeAlreadyExists, name)
@@ -141,11 +130,11 @@ func (s *Service) Rename(ctx context.Context, id uint, name string) (Anime, erro
 		}
 		if len(dirs) > 0 {
 			rootDir := dirs[0]
-			oldPath := filepath.Join(s.config.ImageRootDirectory, oldName)
-			newPath := filepath.Join(s.config.ImageRootDirectory, name)
+			oldPath := filepath.Join(s.config.ImageRootDirectory, rootDir.Name) // use existing File.Name for old path
+			newPath := filepath.Join(s.config.ImageRootDirectory, folderName)
 
-			// Rename in DB
-			rootDir.Name = name
+			// Rename in DB (sanitized for disk)
+			rootDir.Name = folderName
 			if err := s.dbClient.File().Update(ctx, &rootDir); err != nil {
 				return fmt.Errorf("File.Update: %w", err)
 			}
@@ -165,7 +154,7 @@ func (s *Service) Rename(ctx context.Context, id uint, name string) (Anime, erro
 // anime row itself.
 func (s *Service) Delete(ctx context.Context, id uint) error {
 	// verify exists for a clean error
-	anime, err := s.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: id})
+	_, err := s.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: id})
 	if errors.Is(err, db.ErrRecordNotFound) {
 		return fmt.Errorf("%w: id %d", ErrAnimeNotFound, id)
 	}
@@ -185,7 +174,7 @@ func (s *Service) Delete(ctx context.Context, id uint) error {
 	var diskPath string
 	if len(dirs) > 0 {
 		rootDir := dirs[0]
-		diskPath = filepath.Join(s.config.ImageRootDirectory, anime.Name)
+		diskPath = filepath.Join(s.config.ImageRootDirectory, rootDir.Name) // use File.Name (actual folder name on disk)
 		allFileIDs = append(allFileIDs, rootDir.ID)
 
 		// BFS to find all descendant files
@@ -1022,21 +1011,19 @@ func (s *Service) CreateEntry(ctx context.Context, animeID uint, entryType strin
 		entryNumber = nil // other entries don't have a number
 	}
 
-	if err := validateFolderName(displayName); err != nil {
-		return AnimeEntry{}, fmt.Errorf("%w: %s", xerrors.ErrInvalidArgument, err)
-	}
+	folderName := sanitizeFolderName(displayName)
 
-	// Build disk path: <ImageRootDirectory>/<anime-name>/<displayName>
+	// Build disk path: <ImageRootDirectory>/<anime-name>/<folderName>
 	rootDirPath, err := s.resolveFileDiskPath(rootFolder.ID)
 	if err != nil {
 		return AnimeEntry{}, fmt.Errorf("resolveFileDiskPath: %w", err)
 	}
-	dirPath := filepath.Join(rootDirPath, displayName)
+	dirPath := filepath.Join(rootDirPath, folderName)
 
 	var newFile db.File
 	err = db.NewTransaction(ctx, s.dbClient, func(ctx context.Context) error {
 		newFile = db.File{
-			Name:        displayName,
+			Name:        folderName,
 			ParentID:    rootFolder.ID,
 			Type:        db.FileTypeDirectory,
 			EntryType:   entryType,
@@ -1079,9 +1066,7 @@ func (s *Service) CreateSubEntry(ctx context.Context, parentEntryID uint, name s
 		return AnimeEntry{}, fmt.Errorf("%w: name is required", xerrors.ErrInvalidArgument)
 	}
 
-	if err := validateFolderName(name); err != nil {
-		return AnimeEntry{}, fmt.Errorf("%w: %s", xerrors.ErrInvalidArgument, err)
-	}
+	folderName := sanitizeFolderName(name)
 
 	parent, err := s.dbClient.File().FindByValue(ctx, &db.File{ID: parentEntryID})
 	if errors.Is(err, db.ErrRecordNotFound) {
@@ -1123,24 +1108,24 @@ func (s *Service) CreateSubEntry(ctx context.Context, parentEntryID uint, name s
 	if err != nil {
 		return AnimeEntry{}, fmt.Errorf("resolveFileDiskPath: %w", err)
 	}
-	dirPath := filepath.Join(parentDiskPath, name)
+	dirPath := filepath.Join(parentDiskPath, folderName)
 
 	var newFile db.File
 	err = db.NewTransaction(ctx, s.dbClient, func(ctx context.Context) error {
 		newFile = db.File{
-			Name:     name,
+			Name:     folderName,
 			ParentID: parentEntryID,
 			Type:     db.FileTypeDirectory,
 		}
 		if err := s.dbClient.File().Create(ctx, &newFile); err != nil {
 			if isUniqueViolation(err) {
-				return fmt.Errorf("%w: sub-entry %s already exists", xerrors.ErrInvalidArgument, name)
+				return fmt.Errorf("%w: sub-entry %s already exists", xerrors.ErrInvalidArgument, folderName)
 			}
 			return fmt.Errorf("File.Create: %w", err)
 		}
 		if err := os.Mkdir(dirPath, 0755); err != nil {
 			if os.IsExist(err) {
-				return fmt.Errorf("%w: folder %s already exists on disk", xerrors.ErrInvalidArgument, name)
+				return fmt.Errorf("%w: folder %s already exists on disk", xerrors.ErrInvalidArgument, folderName)
 			}
 			return fmt.Errorf("os.Mkdir: %w", err)
 		}
@@ -1165,9 +1150,7 @@ func (s *Service) RenameEntry(ctx context.Context, entryID uint, newName string)
 	if newName == "" {
 		return fmt.Errorf("%w: name is required", xerrors.ErrInvalidArgument)
 	}
-	if err := validateFolderName(newName); err != nil {
-		return fmt.Errorf("%w: %s", xerrors.ErrInvalidArgument, err)
-	}
+	folderName := sanitizeFolderName(newName)
 
 	file, err := s.dbClient.File().FindByValue(ctx, &db.File{ID: entryID})
 	if errors.Is(err, db.ErrRecordNotFound) {
@@ -1180,8 +1163,7 @@ func (s *Service) RenameEntry(ctx context.Context, entryID uint, newName string)
 		return fmt.Errorf("%w: entry id %d is not a directory", xerrors.ErrInvalidArgument, entryID)
 	}
 
-	oldName := file.Name
-	if oldName == newName {
+	if file.Name == folderName {
 		return nil // no-op
 	}
 
@@ -1189,10 +1171,10 @@ func (s *Service) RenameEntry(ctx context.Context, entryID uint, newName string)
 	if err != nil {
 		return fmt.Errorf("resolveFileDiskPath: %w", err)
 	}
-	newPath := filepath.Join(filepath.Dir(oldPath), newName)
+	newPath := filepath.Join(filepath.Dir(oldPath), folderName)
 
 	return db.NewTransaction(ctx, s.dbClient, func(ctx context.Context) error {
-		file.Name = newName
+		file.Name = folderName
 		if err := s.dbClient.File().Update(ctx, &file); err != nil {
 			if isUniqueViolation(err) {
 				return fmt.Errorf("%w: entry %s already exists", xerrors.ErrInvalidArgument, newName)
@@ -1287,6 +1269,37 @@ func (s *Service) NextEntryNumber(animeID uint, entryType string) (uint, error) 
 		}
 	}
 	return maxNum + 1, nil
+}
+
+// UpdateEntryAiringInfo updates the airing season and year on an entry.
+// airingSeason should be one of "WINTER", "SPRING", "SUMMER", "FALL", or "" to clear.
+// airingYear of 0 clears the year.
+func (s *Service) UpdateEntryAiringInfo(ctx context.Context, entryID uint, airingSeason string, airingYear uint) error {
+	// Validate the entry exists and is a directory.
+	file, err := s.dbClient.File().FindByValue(ctx, &db.File{ID: entryID})
+	if err != nil {
+		if errors.Is(err, db.ErrRecordNotFound) {
+			return fmt.Errorf("%w: entry id %d", image.ErrDirectoryNotFound, entryID)
+		}
+		return err
+	}
+	if file.Type != db.FileTypeDirectory {
+		return fmt.Errorf("%w: entry id %d is not a directory", xerrors.ErrInvalidArgument, entryID)
+	}
+
+	// Validate airingSeason.
+	switch airingSeason {
+	case "", db.AiringSeasonWinter, db.AiringSeasonSpring, db.AiringSeasonSummer, db.AiringSeasonFall:
+		// valid
+	default:
+		return fmt.Errorf("%w: invalid airing season %q", xerrors.ErrInvalidArgument, airingSeason)
+	}
+
+	var yearPtr *uint
+	if airingYear > 0 {
+		yearPtr = &airingYear
+	}
+	return s.dbClient.File().UpdateAiringFields(ctx, entryID, airingSeason, yearPtr)
 }
 
 // resolveFileDiskPath walks up the parent chain to build the full disk path

--- a/internal/anime/service.go
+++ b/internal/anime/service.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
@@ -38,13 +39,15 @@ type Service struct {
 	dbClient        *db.Client
 	directoryReader *image.DirectoryReader
 	config          config.Config
+	anilistClient   anilist.Client
 }
 
-func NewService(dbClient *db.Client, directoryReader *image.DirectoryReader, cfg config.Config) *Service {
+func NewService(dbClient *db.Client, directoryReader *image.DirectoryReader, cfg config.Config, anilistClient anilist.Client) *Service {
 	return &Service{
 		dbClient:        dbClient,
 		directoryReader: directoryReader,
 		config:          cfg,
+		anilistClient:   anilistClient,
 	}
 }
 
@@ -793,12 +796,14 @@ func collectDescendantImageIDs(dir *image.Directory, out *[]uint) {
 // AnimeEntry represents a structured entry (season, movie, other) within an
 // anime's folder tree. Each entry is backed by a physical directory on disk.
 type AnimeEntry struct {
-	ID          uint         `json:"id"`
-	Name        string       `json:"name"`
-	EntryType   string       `json:"entryType"`
-	EntryNumber *uint        `json:"entryNumber"` // season number or movie year
-	ImageCount  uint         `json:"imageCount"`
-	Children    []AnimeEntry `json:"children"` // sub-entries (parts)
+	ID           uint         `json:"id"`
+	Name         string       `json:"name"`
+	EntryType    string       `json:"entryType"`
+	EntryNumber  *uint        `json:"entryNumber"` // season number or movie year
+	AiringSeason string       `json:"airingSeason"`
+	AiringYear   *uint        `json:"airingYear"`
+	ImageCount   uint         `json:"imageCount"`
+	Children     []AnimeEntry `json:"children"` // sub-entries (parts)
 }
 
 // GetAnimeEntries returns the structured entries for an anime, sorted by
@@ -856,29 +861,35 @@ func (s *Service) GetAnimeEntries(animeID uint) ([]AnimeEntry, error) {
 			subSubEntries := make([]AnimeEntry, 0)
 			for _, ggc := range gcGreatGrandchildren[gc.ID] {
 				subSubEntries = append(subSubEntries, AnimeEntry{
-					ID:          ggc.ID,
-					Name:        ggc.Name,
-					EntryType:   ggc.EntryType,
-					EntryNumber: ggc.EntryNumber,
-					ImageCount:  imageCounts[ggc.ID],
+					ID:           ggc.ID,
+					Name:         ggc.Name,
+					EntryType:    ggc.EntryType,
+					EntryNumber:  ggc.EntryNumber,
+					AiringSeason: ggc.AiringSeason,
+					AiringYear:   ggc.AiringYear,
+					ImageCount:   imageCounts[ggc.ID],
 				})
 			}
 			subEntries = append(subEntries, AnimeEntry{
-				ID:          gc.ID,
-				Name:        gc.Name,
-				EntryType:   gc.EntryType,
-				EntryNumber: gc.EntryNumber,
-				ImageCount:  imageCounts[gc.ID],
-				Children:    subSubEntries,
+				ID:           gc.ID,
+				Name:         gc.Name,
+				EntryType:    gc.EntryType,
+				EntryNumber:  gc.EntryNumber,
+				AiringSeason: gc.AiringSeason,
+				AiringYear:   gc.AiringYear,
+				ImageCount:   imageCounts[gc.ID],
+				Children:     subSubEntries,
 			})
 		}
 		entries = append(entries, AnimeEntry{
-			ID:          child.ID,
-			Name:        child.Name,
-			EntryType:   child.EntryType,
-			EntryNumber: child.EntryNumber,
-			ImageCount:  imageCounts[child.ID],
-			Children:    subEntries,
+			ID:           child.ID,
+			Name:         child.Name,
+			EntryType:    child.EntryType,
+			EntryNumber:  child.EntryNumber,
+			AiringSeason: child.AiringSeason,
+			AiringYear:   child.AiringYear,
+			ImageCount:   imageCounts[child.ID],
+			Children:     subEntries,
 		})
 	}
 
@@ -1050,11 +1061,13 @@ func (s *Service) CreateEntry(ctx context.Context, animeID uint, entryType strin
 	}
 
 	return AnimeEntry{
-		ID:          newFile.ID,
-		Name:        newFile.Name,
-		EntryType:   newFile.EntryType,
-		EntryNumber: newFile.EntryNumber,
-		ImageCount:  0,
+		ID:           newFile.ID,
+		Name:         newFile.Name,
+		EntryType:    newFile.EntryType,
+		EntryNumber:  newFile.EntryNumber,
+		AiringSeason: newFile.AiringSeason,
+		AiringYear:   newFile.AiringYear,
+		ImageCount:   0,
 	}, nil
 }
 
@@ -1138,9 +1151,11 @@ func (s *Service) CreateSubEntry(ctx context.Context, parentEntryID uint, name s
 	}
 
 	return AnimeEntry{
-		ID:         newFile.ID,
-		Name:       newFile.Name,
-		ImageCount: 0,
+		ID:           newFile.ID,
+		Name:         newFile.Name,
+		AiringSeason: newFile.AiringSeason,
+		AiringYear:   newFile.AiringYear,
+		ImageCount:   0,
 	}, nil
 }
 

--- a/internal/anime/service_test.go
+++ b/internal/anime/service_test.go
@@ -79,6 +79,24 @@ func TestService_Create(t *testing.T) {
 		assert.ErrorIs(t, err, ErrAnimeAlreadyExists)
 	})
 
+	t.Run("sanitizes folder name for names with special chars", func(t *testing.T) {
+		got, err := svc.Create(ctx, "Frieren: Beyond Journey's End")
+		require.NoError(t, err)
+		assert.Equal(t, "Frieren: Beyond Journey's End", got.Name) // display name keeps original
+
+		// Verify folder on disk uses sanitized name
+		dirPath := filepath.Join(te.config.ImageRootDirectory, "Frieren- Beyond Journey's End")
+		info, err := os.Stat(dirPath)
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+
+		// Verify db.File record has sanitized name
+		rootFolder, err := svc.FindAnimeRootFolder(got.ID)
+		require.NoError(t, err)
+		require.NotNil(t, rootFolder)
+		assert.Equal(t, "Frieren- Beyond Journey's End", rootFolder.Name)
+	})
+
 	t.Run("rejects when folder already exists on disk only", func(t *testing.T) {
 		// Create a directory on disk but not in DB. The anime and file rows
 		// will be created successfully, but os.Mkdir will fail.
@@ -120,6 +138,27 @@ func TestService_Rename(t *testing.T) {
 		assert.Equal(t, "Renamed", rootFolder.Name)
 	})
 
+	t.Run("sanitizes folder name on rename with special chars", func(t *testing.T) {
+		got, err := svc.Rename(ctx, a.ID, "Re:Zero")
+		require.NoError(t, err)
+		assert.Equal(t, "Re:Zero", got.Name) // display name keeps original
+
+		// Verify folder on disk uses sanitized name
+		info, err := os.Stat(filepath.Join(te.config.ImageRootDirectory, "Re-Zero"))
+		require.NoError(t, err)
+		assert.True(t, info.IsDir())
+
+		// Verify old folder is gone
+		_, err = os.Stat(filepath.Join(te.config.ImageRootDirectory, "Renamed"))
+		assert.True(t, os.IsNotExist(err))
+
+		// Verify db.File record has sanitized name
+		rootFolder, err := svc.FindAnimeRootFolder(a.ID)
+		require.NoError(t, err)
+		require.NotNil(t, rootFolder)
+		assert.Equal(t, "Re-Zero", rootFolder.Name)
+	})
+
 	t.Run("rejects empty name", func(t *testing.T) {
 		_, err := svc.Rename(ctx, a.ID, "  ")
 		require.Error(t, err)
@@ -145,7 +184,7 @@ func TestService_Rename(t *testing.T) {
 	t.Run("rejects duplicate name", func(t *testing.T) {
 		other, err := svc.Create(ctx, "Other")
 		require.NoError(t, err)
-		_, err = svc.Rename(ctx, other.ID, "Renamed")
+		_, err = svc.Rename(ctx, other.ID, "Re:Zero") // a was renamed to "Re:Zero" above
 		require.Error(t, err)
 		assert.ErrorIs(t, err, ErrAnimeAlreadyExists)
 	})
@@ -1570,30 +1609,33 @@ func TestSortEntries(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func TestValidateFolderName(t *testing.T) {
-	t.Run("rejects empty name", func(t *testing.T) {
-		err := validateFolderName("")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "cannot be empty")
-	})
-
-	t.Run("rejects name with invalid characters", func(t *testing.T) {
-		for _, name := range []string{"foo<bar", "foo>bar", `foo"bar`, "foo|bar", "foo?bar", "foo*bar", "foo:bar", "foo\\bar", "foo/bar"} {
-			err := validateFolderName(name)
-			require.Error(t, err, "expected error for name: %s", name)
-			assert.Contains(t, err.Error(), "invalid characters")
+func TestSanitizeFolderName(t *testing.T) {
+	t.Run("replaces invalid characters with dash", func(t *testing.T) {
+		tests := map[string]string{
+			"foo<bar":  "foo-bar",
+			"foo>bar":  "foo-bar",
+			`foo"bar`:  "foo-bar",
+			"foo|bar":  "foo-bar",
+			"foo?bar":  "foo-bar",
+			"foo*bar":  "foo-bar",
+			"foo:bar":  "foo-bar",
+			"foo\\bar": "foo-bar",
+			"foo/bar":  "foo-bar",
+		}
+		for input, expected := range tests {
+			assert.Equal(t, expected, sanitizeFolderName(input), "input: %s", input)
 		}
 	})
 
-	t.Run("rejects dot names", func(t *testing.T) {
-		require.Error(t, validateFolderName("."))
-		require.Error(t, validateFolderName(".."))
-	})
-
-	t.Run("accepts valid names", func(t *testing.T) {
+	t.Run("leaves valid names unchanged", func(t *testing.T) {
 		for _, name := range []string{"Season 1", "Part A", "Specials", "Bocchi the Rock!"} {
-			require.NoError(t, validateFolderName(name), "expected no error for name: %s", name)
+			assert.Equal(t, name, sanitizeFolderName(name), "name: %s", name)
 		}
+	})
+
+	t.Run("handles multiple invalid characters", func(t *testing.T) {
+		assert.Equal(t, "Frieren- Beyond Journey's End", sanitizeFolderName("Frieren: Beyond Journey's End"))
+		assert.Equal(t, "Series- The Movie", sanitizeFolderName("Series: The Movie"))
 	})
 }
 
@@ -1629,17 +1671,16 @@ func TestService_CreateEntry_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "movie year must be between 1900 and 2100")
 	})
 
-	t.Run("rejects name with invalid characters", func(t *testing.T) {
-		_, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeOther, nil, "Bad<Name")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
-		assert.Contains(t, err.Error(), "invalid characters")
+	t.Run("sanitizes name with invalid characters", func(t *testing.T) {
+		entry, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeOther, nil, "Angle<Bracket")
+		require.NoError(t, err)
+		assert.Equal(t, "Angle-Bracket", entry.Name)
 	})
 
-	t.Run("rejects name with colon", func(t *testing.T) {
-		_, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeOther, nil, "Bad:Name")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
+	t.Run("sanitizes name with colon", func(t *testing.T) {
+		entry, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeOther, nil, "Frieren: Beyond")
+		require.NoError(t, err)
+		assert.Equal(t, "Frieren- Beyond", entry.Name)
 	})
 
 	t.Run("accepts valid season with explicit number", func(t *testing.T) {
@@ -1724,7 +1765,7 @@ func TestService_NextEntryNumber_RejectsNonSeason(t *testing.T) {
 	})
 }
 
-func TestService_RenameEntry_InvalidChars(t *testing.T) {
+func TestService_RenameEntry_SanitizesChars(t *testing.T) {
 	te := newTester(t)
 	svc := te.service()
 	ctx := context.Background()
@@ -1735,15 +1776,19 @@ func TestService_RenameEntry_InvalidChars(t *testing.T) {
 	entry, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeOther, nil, "ValidName")
 	require.NoError(t, err)
 
-	t.Run("rejects rename with invalid characters", func(t *testing.T) {
-		err := svc.RenameEntry(ctx, entry.ID, "Bad|Name")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
-		assert.Contains(t, err.Error(), "invalid characters")
+	t.Run("sanitizes rename with invalid characters", func(t *testing.T) {
+		err := svc.RenameEntry(ctx, entry.ID, "Pipe|Name")
+		require.NoError(t, err)
+
+		// Verify the file was renamed with sanitized name on disk
+		dirPath := filepath.Join(te.config.ImageRootDirectory, "RenameCharAnime", "Pipe-Name")
+		info, statErr := os.Stat(dirPath)
+		require.NoError(t, statErr)
+		assert.True(t, info.IsDir())
 	})
 }
 
-func TestService_CreateSubEntry_InvalidChars(t *testing.T) {
+func TestService_CreateSubEntry_SanitizesChars(t *testing.T) {
 	te := newTester(t)
 	svc := te.service()
 	ctx := context.Background()
@@ -1754,11 +1799,16 @@ func TestService_CreateSubEntry_InvalidChars(t *testing.T) {
 	season, err := svc.CreateEntry(ctx, a.ID, db.EntryTypeSeason, nil, "")
 	require.NoError(t, err)
 
-	t.Run("rejects sub-entry with invalid characters", func(t *testing.T) {
-		_, err := svc.CreateSubEntry(ctx, season.ID, "Bad*Name")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
-		assert.Contains(t, err.Error(), "invalid characters")
+	t.Run("sanitizes sub-entry with invalid characters", func(t *testing.T) {
+		sub, err := svc.CreateSubEntry(ctx, season.ID, "Star*Name")
+		require.NoError(t, err)
+		assert.Equal(t, "Star-Name", sub.Name)
+
+		// Verify the folder was created with sanitized name on disk
+		dirPath := filepath.Join(te.config.ImageRootDirectory, "SubCharAnime", "Season 1", "Star-Name")
+		info, statErr := os.Stat(dirPath)
+		require.NoError(t, statErr)
+		assert.True(t, info.IsDir())
 	})
 }
 

--- a/internal/anime/service_test.go
+++ b/internal/anime/service_test.go
@@ -1907,3 +1907,77 @@ func TestService_UpdateEntryType(t *testing.T) {
 		assert.Nil(t, got.EntryNumber)
 	})
 }
+
+func TestService_UpdateEntryAiringInfo(t *testing.T) {
+	te := newTester(t)
+	svc := te.service()
+	ctx := context.Background()
+
+	created, err := svc.Create(ctx, "AiringInfoTest")
+	require.NoError(t, err)
+
+	entry, err := svc.CreateEntry(ctx, created.ID, db.EntryTypeSeason, nil, "")
+	require.NoError(t, err)
+
+	t.Run("sets airing season and year", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(ctx, entry.ID, db.AiringSeasonSpring, 2024)
+		require.NoError(t, err)
+
+		got, err := te.dbClient.File().FindByValue(ctx, &db.File{ID: entry.ID})
+		require.NoError(t, err)
+		assert.Equal(t, db.AiringSeasonSpring, got.AiringSeason)
+		require.NotNil(t, got.AiringYear)
+		assert.Equal(t, uint(2024), *got.AiringYear)
+	})
+
+	t.Run("clears airing info with empty values", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(ctx, entry.ID, "", 0)
+		require.NoError(t, err)
+
+		got, err := te.dbClient.File().FindByValue(ctx, &db.File{ID: entry.ID})
+		require.NoError(t, err)
+		assert.Empty(t, got.AiringSeason)
+		assert.Nil(t, got.AiringYear)
+	})
+
+	t.Run("all valid seasons", func(t *testing.T) {
+		for _, season := range []string{
+			db.AiringSeasonWinter,
+			db.AiringSeasonSpring,
+			db.AiringSeasonSummer,
+			db.AiringSeasonFall,
+		} {
+			err := svc.UpdateEntryAiringInfo(ctx, entry.ID, season, 2025)
+			require.NoError(t, err, "season %s should be valid", season)
+		}
+	})
+
+	t.Run("rejects invalid season", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(ctx, entry.ID, "INVALID", 2024)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
+	})
+
+	t.Run("rejects nonexistent entry", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(ctx, 99999, db.AiringSeasonFall, 2024)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, image.ErrDirectoryNotFound)
+	})
+
+	t.Run("rejects non-directory file", func(t *testing.T) {
+		// Create an image file under the root folder
+		rootFolder, err := svc.FindAnimeRootFolder(created.ID)
+		require.NoError(t, err)
+
+		imgFile := db.File{
+			Name:     "test.jpg",
+			ParentID: rootFolder.ID,
+			Type:     db.FileTypeImage,
+		}
+		require.NoError(t, te.dbClient.File().Create(ctx, &imgFile))
+
+		err = svc.UpdateEntryAiringInfo(ctx, imgFile.ID, db.AiringSeasonFall, 2024)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, xerrors.ErrInvalidArgument)
+	})
+}

--- a/internal/db/anime.go
+++ b/internal/db/anime.go
@@ -10,6 +10,7 @@ import (
 type Anime struct {
 	ID        uint   `gorm:"primarykey"`
 	Name      string `gorm:"uniqueIndex"`
+	AniListID *int   `gorm:"index"`
 	CreatedAt uint   `gorm:"autoCreateTime"`
 	UpdatedAt uint   `gorm:"autoUpdateTime"`
 }

--- a/internal/db/files.go
+++ b/internal/db/files.go
@@ -17,6 +17,11 @@ const (
 	EntryTypeSeason = "season"
 	EntryTypeMovie  = "movie"
 	EntryTypeOther  = "other"
+
+	AiringSeasonWinter = "WINTER"
+	AiringSeasonSpring = "SPRING"
+	AiringSeasonSummer = "SUMMER"
+	AiringSeasonFall   = "FALL"
 )
 
 type File struct {
@@ -40,6 +45,13 @@ type File struct {
 
 	// EntryNumber is the season number or movie year. NULL when not applicable.
 	EntryNumber *uint `gorm:"column:entry_number"`
+
+	// AiringSeason is the airing season: "WINTER", "SPRING", "SUMMER", "FALL".
+	// NULL when not applicable.
+	AiringSeason string `gorm:"column:airing_season"`
+
+	// AiringYear is the year the entry aired. NULL when not applicable.
+	AiringYear *uint `gorm:"column:airing_year"`
 
 	// ContentHash stores a hex-encoded SHA256 hash of the image file content.
 	// It is computed on import and used for fast corruption detection.
@@ -181,9 +193,23 @@ func (client *FileClient) FindDirectChildDirectories(parentID uint) ([]File, err
 // UpdateEntryFields updates entry_type and entry_number on the given file ID.
 // Uses GORM's Updates with a map so that nil/zero values are properly saved.
 func (client *FileClient) UpdateEntryFields(ctx context.Context, fileID uint, entryType string, entryNumber *uint) error {
-	updates := map[string]interface{}{
+	updates := map[string]any{
 		"entry_type":   entryType,
 		"entry_number": entryNumber,
+	}
+	return client.getTransaction(ctx).
+		Model(&File{}).
+		Where("id = ?", fileID).
+		Updates(updates).
+		Error
+}
+
+// UpdateAiringFields updates airing_season and airing_year on the given file ID.
+// Uses GORM's Updates with a map so that nil/zero values are properly saved.
+func (client *FileClient) UpdateAiringFields(ctx context.Context, fileID uint, airingSeason string, airingYear *uint) error {
+	updates := map[string]any{
+		"airing_season": airingSeason,
+		"airing_year":   airingYear,
 	}
 	return client.getTransaction(ctx).
 		Model(&File{}).

--- a/internal/db/files_test.go
+++ b/internal/db/files_test.go
@@ -461,3 +461,36 @@ func TestFileClient_ContentHashField(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.Equal(t, hash, got[0].ContentHash)
 }
+
+func TestFileClient_UpdateAiringFields(t *testing.T) {
+	testClient := NewTestClient(t)
+	testClient.Truncate(t, File{})
+	ctx := context.Background()
+
+	files := []File{
+		{ID: 8001, ParentID: 0, Name: "dir1", Type: FileTypeDirectory},
+	}
+	LoadTestData(t, testClient, files)
+
+	t.Run("sets airing season and year", func(t *testing.T) {
+		year := uint(2024)
+		err := testClient.File().UpdateAiringFields(ctx, 8001, AiringSeasonSpring, &year)
+		require.NoError(t, err)
+
+		got, err := testClient.File().FindByValue(ctx, &File{ID: 8001})
+		require.NoError(t, err)
+		assert.Equal(t, AiringSeasonSpring, got.AiringSeason)
+		require.NotNil(t, got.AiringYear)
+		assert.Equal(t, uint(2024), *got.AiringYear)
+	})
+
+	t.Run("clears airing fields", func(t *testing.T) {
+		err := testClient.File().UpdateAiringFields(ctx, 8001, "", nil)
+		require.NoError(t, err)
+
+		got, err := testClient.File().FindByValue(ctx, &File{ID: 8001})
+		require.NoError(t, err)
+		assert.Empty(t, got.AiringSeason)
+		assert.Nil(t, got.AiringYear)
+	})
+}

--- a/internal/frontend/anilist_types.go
+++ b/internal/frontend/anilist_types.go
@@ -1,0 +1,21 @@
+package frontend
+
+// AniListSearchResult is a search result exposed to the frontend.
+type AniListSearchResult struct {
+	ID            int    `json:"id"`
+	TitleRomaji   string `json:"titleRomaji"`
+	TitleEnglish  string `json:"titleEnglish"`
+	TitleNative   string `json:"titleNative"`
+	Format        string `json:"format"`
+	Status        string `json:"status"`
+	Season        string `json:"season"`
+	SeasonYear    int    `json:"seasonYear"`
+	Episodes      int    `json:"episodes"`
+	CoverImageURL string `json:"coverImageUrl"`
+}
+
+// AniListImportResult is the outcome of importing from AniList.
+type AniListImportResult struct {
+	EntriesCreated    int `json:"entriesCreated"`
+	CharactersCreated int `json:"charactersCreated"`
+}

--- a/internal/frontend/anime.go
+++ b/internal/frontend/anime.go
@@ -14,8 +14,9 @@ import (
 
 // Anime is the JSON-friendly anime model exposed to the frontend.
 type Anime struct {
-	ID   uint   `json:"id"`
-	Name string `json:"name"`
+	ID        uint   `json:"id"`
+	Name      string `json:"name"`
+	AniListID *int   `json:"aniListId"`
 }
 
 // AnimeListItem is an anime row plus its image count for the list page.
@@ -61,12 +62,14 @@ type UnassignedFolder struct {
 
 // AnimeEntryInfo is an entry (season, movie, other) in the anime's folder tree.
 type AnimeEntryInfo struct {
-	ID          uint             `json:"id"`
-	Name        string           `json:"name"`
-	EntryType   string           `json:"entryType"`
-	EntryNumber *uint            `json:"entryNumber"`
-	ImageCount  uint             `json:"imageCount"`
-	Children    []AnimeEntryInfo `json:"children"`
+	ID           uint             `json:"id"`
+	Name         string           `json:"name"`
+	EntryType    string           `json:"entryType"`
+	EntryNumber  *uint            `json:"entryNumber"`
+	AiringSeason string           `json:"airingSeason"`
+	AiringYear   *uint            `json:"airingYear"`
+	ImageCount   uint             `json:"imageCount"`
+	Children     []AnimeEntryInfo `json:"children"`
 }
 
 // AnimeDetailsResponse is the payload of the landing page request.
@@ -152,6 +155,12 @@ func (s *AnimeService) GetAnimeDetails(ctx context.Context, id uint) (AnimeDetai
 		return AnimeDetailsResponse{}, err
 	}
 
+	// Read the DB row to get AniListID (core Anime struct does not carry it).
+	dbAnime, err := s.dbClient.Anime().FindByValue(ctx, &db.Anime{ID: id})
+	if err != nil {
+		return AnimeDetailsResponse{}, fmt.Errorf("Anime.FindByValue: %w", err)
+	}
+
 	// Derive tags from images in the anime's folder tree
 	derivedTags, err := s.core.DeriveTagsForAnime(id)
 	if err != nil {
@@ -195,7 +204,7 @@ func (s *AnimeService) GetAnimeDetails(ctx context.Context, id uint) (AnimeDetai
 	entryInfos := convertEntries(coreEntries)
 
 	return AnimeDetailsResponse{
-		Anime:      Anime{ID: a.ID, Name: a.Name},
+		Anime:      Anime{ID: a.ID, Name: a.Name, AniListID: dbAnime.AniListID},
 		Tags:       tagInfos,
 		Folders:    folderInfos,
 		FolderTree: folderTree,
@@ -525,6 +534,46 @@ func (s *AnimeService) GetNextEntryNumber(animeID uint, entryType string) (uint,
 	return s.core.NextEntryNumber(animeID, entryType)
 }
 
+// SearchAniList searches for anime on AniList.
+func (s *AnimeService) SearchAniList(ctx context.Context, query string) ([]AniListSearchResult, error) {
+	results, err := s.core.SearchAniList(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AniListSearchResult, len(results))
+	for i, r := range results {
+		coverURL := r.CoverImage.Large
+		if coverURL == "" {
+			coverURL = r.CoverImage.Medium
+		}
+		out[i] = AniListSearchResult{
+			ID:            r.ID,
+			TitleRomaji:   r.Title.Romaji,
+			TitleEnglish:  r.Title.English,
+			TitleNative:   r.Title.Native,
+			Format:        r.Format,
+			Status:        r.Status,
+			Season:        r.Season,
+			SeasonYear:    r.SeasonYear,
+			Episodes:      r.Episodes,
+			CoverImageURL: coverURL,
+		}
+	}
+	return out, nil
+}
+
+// ImportFromAniList imports entries and characters from AniList.
+func (s *AnimeService) ImportFromAniList(ctx context.Context, animeID uint, aniListID int) (AniListImportResult, error) {
+	result, err := s.core.ImportFromAniList(ctx, animeID, aniListID)
+	if err != nil {
+		return AniListImportResult{}, err
+	}
+	return AniListImportResult{
+		EntriesCreated:    result.EntriesCreated,
+		CharactersCreated: result.CharactersCreated,
+	}, nil
+}
+
 func convertEntries(entries []anime.AnimeEntry) []AnimeEntryInfo {
 	if entries == nil {
 		return nil
@@ -542,11 +591,13 @@ func convertEntry(e anime.AnimeEntry) AnimeEntryInfo {
 		children = append(children, convertEntry(c))
 	}
 	return AnimeEntryInfo{
-		ID:          e.ID,
-		Name:        e.Name,
-		EntryType:   e.EntryType,
-		EntryNumber: e.EntryNumber,
-		ImageCount:  e.ImageCount,
-		Children:    children,
+		ID:           e.ID,
+		Name:         e.Name,
+		EntryType:    e.EntryType,
+		EntryNumber:  e.EntryNumber,
+		AiringSeason: e.AiringSeason,
+		AiringYear:   e.AiringYear,
+		ImageCount:   e.ImageCount,
+		Children:     children,
 	}
 }

--- a/internal/frontend/anime.go
+++ b/internal/frontend/anime.go
@@ -529,6 +529,11 @@ func (s *AnimeService) UpdateEntryType(ctx context.Context, entryID uint, entryT
 	return s.core.UpdateEntryType(ctx, entryID, entryType, entryNumber)
 }
 
+// UpdateEntryAiringInfo updates the airing season and year on an entry.
+func (s *AnimeService) UpdateEntryAiringInfo(entryID uint, airingSeason string, airingYear uint) error {
+	return s.core.UpdateEntryAiringInfo(context.Background(), entryID, airingSeason, airingYear)
+}
+
 // GetNextEntryNumber returns the next entry number for the given type.
 func (s *AnimeService) GetNextEntryNumber(animeID uint, entryType string) (uint, error) {
 	return s.core.NextEntryNumber(animeID, entryType)

--- a/internal/frontend/anime_test.go
+++ b/internal/frontend/anime_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
 	animecore "github.com/michael-freling/anime-image-viewer/internal/anime"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
@@ -1062,5 +1063,226 @@ func TestAnimeService_UpdateEntryType(t *testing.T) {
 	t.Run("rejects season with nil number", func(t *testing.T) {
 		err := svc.UpdateEntryType(ctx, legacyDir.ID, db.EntryTypeSeason, nil)
 		require.Error(t, err)
+	})
+}
+
+// mockAniListClient implements anilist.Client for frontend tests.
+type mockAniListClient struct {
+	searchResult  []anilist.MediaSearchResult
+	searchErr     error
+	detailResults map[int]*anilist.MediaDetail
+	detailErr     error
+}
+
+func (m *mockAniListClient) SearchAnime(_ context.Context, _ string, _ int, _ int) ([]anilist.MediaSearchResult, error) {
+	return m.searchResult, m.searchErr
+}
+
+func (m *mockAniListClient) GetAnimeDetail(_ context.Context, id int) (*anilist.MediaDetail, error) {
+	if m.detailErr != nil {
+		return nil, m.detailErr
+	}
+	return m.detailResults[id], nil
+}
+
+func TestAnimeService_UpdateEntryAiringInfo(t *testing.T) {
+	tester := newTester(t)
+	tester.dbClient.Truncate(t, db.File{}, db.Tag{}, db.Anime{}, db.FileTag{})
+	svc := tester.getAnimeService()
+	ctx := context.Background()
+
+	a, err := svc.CreateAnime(ctx, "AiringShow")
+	require.NoError(t, err)
+
+	entry, err := svc.CreateAnimeEntry(ctx, a.ID, db.EntryTypeSeason, nil, "")
+	require.NoError(t, err)
+
+	t.Run("sets airing season and year", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(entry.ID, db.AiringSeasonSpring, 2024)
+		require.NoError(t, err)
+
+		entries, err := svc.GetAnimeEntries(a.ID)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "SPRING", entries[0].AiringSeason)
+		require.NotNil(t, entries[0].AiringYear)
+		assert.Equal(t, uint(2024), *entries[0].AiringYear)
+	})
+
+	t.Run("clears airing info with empty season and zero year", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(entry.ID, "", 0)
+		require.NoError(t, err)
+
+		entries, err := svc.GetAnimeEntries(a.ID)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		assert.Empty(t, entries[0].AiringSeason)
+		assert.Nil(t, entries[0].AiringYear)
+	})
+
+	t.Run("rejects invalid season", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(entry.ID, "INVALID", 2024)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects nonexistent entry", func(t *testing.T) {
+		err := svc.UpdateEntryAiringInfo(99999, db.AiringSeasonFall, 2024)
+		require.Error(t, err)
+	})
+}
+
+func TestAnimeService_SearchAniList(t *testing.T) {
+	tester := newTester(t)
+	tester.dbClient.Truncate(t, db.File{}, db.Tag{}, db.Anime{}, db.FileTag{})
+	ctx := context.Background()
+
+	t.Run("returns search results with cover image", func(t *testing.T) {
+		mock := &mockAniListClient{
+			searchResult: []anilist.MediaSearchResult{
+				{
+					ID: 1,
+					Title: anilist.MediaTitle{
+						Romaji:  "Shingeki no Kyojin",
+						English: "Attack on Titan",
+						Native:  "進撃の巨人",
+					},
+					Format:     "TV",
+					Status:     "FINISHED",
+					Season:     "SPRING",
+					SeasonYear: 2013,
+					Episodes:   25,
+					CoverImage: anilist.CoverImage{
+						Large:  "https://example.com/large.jpg",
+						Medium: "https://example.com/medium.jpg",
+					},
+				},
+				{
+					ID: 2,
+					Title: anilist.MediaTitle{
+						Romaji: "Bocchi the Rock!",
+					},
+					Format:     "TV",
+					Status:     "FINISHED",
+					Season:     "FALL",
+					SeasonYear: 2022,
+					Episodes:   12,
+					CoverImage: anilist.CoverImage{
+						Medium: "https://example.com/bocchi_medium.jpg",
+					},
+				},
+			},
+		}
+		svc := tester.getAnimeServiceWithAniList(mock)
+
+		results, err := svc.SearchAniList(ctx, "attack")
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		// First result: has Large cover image
+		assert.Equal(t, 1, results[0].ID)
+		assert.Equal(t, "Shingeki no Kyojin", results[0].TitleRomaji)
+		assert.Equal(t, "Attack on Titan", results[0].TitleEnglish)
+		assert.Equal(t, "進撃の巨人", results[0].TitleNative)
+		assert.Equal(t, "TV", results[0].Format)
+		assert.Equal(t, "FINISHED", results[0].Status)
+		assert.Equal(t, "SPRING", results[0].Season)
+		assert.Equal(t, 2013, results[0].SeasonYear)
+		assert.Equal(t, 25, results[0].Episodes)
+		assert.Equal(t, "https://example.com/large.jpg", results[0].CoverImageURL)
+
+		// Second result: no Large, falls back to Medium
+		assert.Equal(t, 2, results[1].ID)
+		assert.Equal(t, "https://example.com/bocchi_medium.jpg", results[1].CoverImageURL)
+	})
+
+	t.Run("returns nil on error", func(t *testing.T) {
+		mock := &mockAniListClient{
+			searchErr: errors.New("network error"),
+		}
+		svc := tester.getAnimeServiceWithAniList(mock)
+
+		results, err := svc.SearchAniList(ctx, "test")
+		require.Error(t, err)
+		assert.Nil(t, results)
+	})
+
+	t.Run("nil anilist client returns error", func(t *testing.T) {
+		svc := tester.getAnimeService() // no anilist client
+
+		results, err := svc.SearchAniList(ctx, "test")
+		require.Error(t, err)
+		assert.Nil(t, results)
+		assert.Contains(t, err.Error(), "anilist client is not configured")
+	})
+}
+
+func TestAnimeService_ImportFromAniList(t *testing.T) {
+	tester := newTester(t)
+	tester.dbClient.Truncate(t, db.File{}, db.Tag{}, db.Anime{}, db.FileTag{})
+	ctx := context.Background()
+
+	t.Run("imports entries and characters", func(t *testing.T) {
+		mock := &mockAniListClient{
+			detailResults: map[int]*anilist.MediaDetail{
+				100: {
+					ID: 100,
+					Title: anilist.MediaTitle{
+						Romaji:  "Bocchi the Rock!",
+						English: "Bocchi the Rock!",
+					},
+					Format:     "TV",
+					Season:     "FALL",
+					SeasonYear: 2022,
+					Characters: []anilist.Character{
+						{ID: 1, Role: "MAIN", Name: struct {
+							Full   string `json:"full"`
+							Native string `json:"native"`
+						}{Full: "Hitori Gotoh"}},
+						{ID: 2, Role: "SUPPORTING", Name: struct {
+							Full   string `json:"full"`
+							Native string `json:"native"`
+						}{Full: "Nijika Ijichi"}},
+					},
+				},
+			},
+		}
+		svc := tester.getAnimeServiceWithAniList(mock)
+
+		a, err := svc.CreateAnime(ctx, "Bocchi")
+		require.NoError(t, err)
+
+		result, err := svc.ImportFromAniList(ctx, a.ID, 100)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, result.EntriesCreated)
+		assert.Equal(t, 2, result.CharactersCreated)
+	})
+
+	t.Run("error on nonexistent anime", func(t *testing.T) {
+		mock := &mockAniListClient{
+			detailResults: map[int]*anilist.MediaDetail{
+				100: {
+					ID:     100,
+					Title:  anilist.MediaTitle{Romaji: "Test"},
+					Format: "TV",
+				},
+			},
+		}
+		svc := tester.getAnimeServiceWithAniList(mock)
+
+		_, err := svc.ImportFromAniList(ctx, 99999, 100)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, animecore.ErrAnimeNotFound))
+	})
+
+	t.Run("nil anilist client returns error", func(t *testing.T) {
+		svc := tester.getAnimeService() // no anilist client
+
+		a, err := svc.CreateAnime(ctx, "NilClientTest")
+		require.NoError(t, err)
+
+		_, err = svc.ImportFromAniList(ctx, a.ID, 100)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "anilist client is not configured")
 	})
 }

--- a/internal/frontend/main_test.go
+++ b/internal/frontend/main_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
 	"github.com/michael-freling/anime-image-viewer/internal/anime"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
 	"github.com/michael-freling/anime-image-viewer/internal/db"
@@ -109,9 +110,23 @@ func (tester tester) getAnimeCoreService() *anime.Service {
 	return anime.NewService(tester.dbClient.Client, tester.getDirectoryReader(), tester.config, nil)
 }
 
+func (tester tester) getAnimeCoreServiceWithAniList(client anilist.Client) *anime.Service {
+	return anime.NewService(tester.dbClient.Client, tester.getDirectoryReader(), tester.config, client)
+}
+
 func (tester tester) getAnimeService() *AnimeService {
 	return NewAnimeService(
 		tester.getAnimeCoreService(),
+		tester.dbClient.Client,
+		tester.getDirectoryReader(),
+		tester.getTagReader(),
+		tester.getFileReader(),
+	)
+}
+
+func (tester tester) getAnimeServiceWithAniList(client anilist.Client) *AnimeService {
+	return NewAnimeService(
+		tester.getAnimeCoreServiceWithAniList(client),
 		tester.dbClient.Client,
 		tester.getDirectoryReader(),
 		tester.getTagReader(),

--- a/internal/frontend/main_test.go
+++ b/internal/frontend/main_test.go
@@ -106,7 +106,7 @@ func (tester tester) getTagService() *TagService {
 }
 
 func (tester tester) getAnimeCoreService() *anime.Service {
-	return anime.NewService(tester.dbClient.Client, tester.getDirectoryReader(), tester.config)
+	return anime.NewService(tester.dbClient.Client, tester.getDirectoryReader(), tester.config, nil)
 }
 
 func (tester tester) getAnimeService() *AnimeService {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/michael-freling/anime-image-viewer/internal/anilist"
 	"github.com/michael-freling/anime-image-viewer/internal/anime"
 	"github.com/michael-freling/anime-image-viewer/internal/backup"
 	"github.com/michael-freling/anime-image-viewer/internal/config"
@@ -151,7 +152,8 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 	backupFrontendService := frontend.NewBackupFrontendService(logger, conf)
 	configFrontendService := frontend.NewConfigFrontendService(logger, conf)
 
-	animeCoreService := anime.NewService(dbClient, directoryReader, conf)
+	anilistClient := anilist.NewHTTPClient()
+	animeCoreService := anime.NewService(dbClient, directoryReader, conf, anilistClient)
 	animeFrontendService := frontend.NewAnimeService(
 		animeCoreService,
 		dbClient,


### PR DESCRIPTION
## Summary

- Integrate AniList GraphQL API to search and import anime metadata — seasons, movies, and characters are auto-imported when creating or linking an anime
- BFS traversal follows SEQUEL/PREQUEL chains with per-entry API calls and 2s throttling to stay within rate limits; movies are also fetched individually for accurate year data
- Group multi-part seasons (e.g., "Attack on Titan Season 3 Part 2") under a parent entry using title-based heuristics, with AniList titles as folder names
- Sanitize folder names for invalid filesystem characters (`:`, `<>`, etc.) across all 5 creation paths while preserving display names
- Consolidate entry context menu into a single "Edit" modal with name, airing info, and type (for top-level untyped entries only); remove Set Type from sub-entries
- Dim future/unaired seasons with reduced opacity and italic text; sort characters by tagged image count
- Show loading spinner on Create button during AniList import; disable modal interaction until complete
- Re-imports update airing info on existing parent entries, sub-entries, and movies

## Test plan

- [x] Go build passes
- [x] All Go tests pass (including 20+ new AniList import tests, re-import tests, service tests)
- [x] TypeScript type-check clean
- [x] Frontend lint and tests pass
- [x] Coverage >= 90% threshold
- [x] Manual: create anime with AniList search, verify seasons/movies/characters imported with airing info
- [x] Manual: edit entry name + airing info in consolidated modal
- [x] Manual: verify future seasons dimmed, characters sorted by image count

🤖 Generated with [Claude Code](https://claude.com/claude-code)