### PR TITLE
feat: improve image viewer with zoom/pan and OS open button

### DIFF
--- a/frontend/src/components/Images/ImageWindow.tsx
+++ b/frontend/src/components/Images/ImageWindow.tsx
@@ -1,17 +1,15 @@
 import {
   ArrowBackIos,
   ArrowForwardIos,
+  OpenInNew,
   ZoomIn,
   ZoomOut,
   ZoomOutMap,
 } from "@mui/icons-material";
 import { Box, IconButton, ModalClose } from "@mui/joy";
 import { FC, useEffect, useState } from "react";
-import {
-  TransformComponent,
-  TransformWrapper,
-  useControls,
-} from "react-zoom-pan-pinch";
+import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
+import { ImageService } from "../../../bindings/github.com/michael-freling/anime-image-viewer/internal/frontend";
 import { ViewImageType } from "./ViewImage";
 
 interface ImageWindowProps {
@@ -19,32 +17,10 @@ interface ImageWindowProps {
   initialId: number;
 }
 
-const TransformControls = () => {
-  const { zoomIn, zoomOut, resetTransform } = useControls();
-
-  const iconSize = "lg";
-  return (
-    <Box
-      sx={{
-        position: "absolute",
-        top: 10,
-        left: 10,
-        zIndex: 10,
-        p: 0,
-        m: 0,
-      }}
-    >
-      <IconButton size={iconSize} onClick={() => zoomIn()}>
-        <ZoomIn />
-      </IconButton>
-      <IconButton size={iconSize} onClick={() => zoomOut()}>
-        <ZoomOut />
-      </IconButton>
-      <IconButton size={iconSize} onClick={() => resetTransform()}>
-        <ZoomOutMap />
-      </IconButton>
-    </Box>
-  );
+const controlButtonSx = {
+  color: "white",
+  bgcolor: "rgba(0,0,0,0.5)",
+  "&:hover": { bgcolor: "rgba(0,0,0,0.7)" },
 };
 
 const ImageWindow: FC<ImageWindowProps> = ({ images, initialId }) => {
@@ -57,51 +33,124 @@ const ImageWindow: FC<ImageWindowProps> = ({ images, initialId }) => {
 
   console.debug("ImageWindow", { images, initialId, initialIndex, index });
 
+  const handleOpenInOS = async () => {
+    try {
+      await ImageService.OpenImageInOS(images[index].id);
+    } catch (e) {
+      console.error("Failed to open image in OS", e);
+    }
+  };
+
   // https://github.com/BetterTyped/react-zoom-pan-pinch
   return (
-    <TransformWrapper initialScale={1}>
-      {() => (
-        <>
-          <Box sx={{ position: "relative" }}>
-            <TransformComponent>
+    <Box
+      sx={{
+        width: "100%",
+        height: "100vh",
+        bgcolor: "black",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      <TransformWrapper
+        key={images[index].id}
+        initialScale={1}
+        minScale={0.5}
+        maxScale={20}
+        centerOnInit={true}
+        centerZoomedOut={true}
+        doubleClick={{ mode: "toggle", step: 2 }}
+      >
+        {({ zoomIn, zoomOut, resetTransform }) => (
+          <>
+            <TransformComponent
+              wrapperStyle={{ width: "100%", height: "100vh" }}
+            >
               <img
                 src={images[index].path}
-                style={{ width: "100%", height: "auto" }}
+                style={{ maxWidth: "100vw", maxHeight: "100vh" }}
               />
             </TransformComponent>
+            <Box
+              sx={{
+                position: "absolute",
+                top: 10,
+                left: 10,
+                zIndex: 10,
+                display: "flex",
+                flexDirection: "column",
+                gap: 0.5,
+              }}
+            >
+              <IconButton
+                size="lg"
+                sx={controlButtonSx}
+                onClick={() => zoomIn()}
+              >
+                <ZoomIn />
+              </IconButton>
+              <IconButton
+                size="lg"
+                sx={controlButtonSx}
+                onClick={() => zoomOut()}
+              >
+                <ZoomOut />
+              </IconButton>
+              <IconButton
+                size="lg"
+                sx={controlButtonSx}
+                onClick={() => resetTransform()}
+              >
+                <ZoomOutMap />
+              </IconButton>
+              <IconButton
+                size="lg"
+                sx={controlButtonSx}
+                onClick={handleOpenInOS}
+              >
+                <OpenInNew />
+              </IconButton>
+            </Box>
+          </>
+        )}
+      </TransformWrapper>
 
-            <ModalClose />
-            <TransformControls />
-            <IconButton
-              sx={{
-                position: "absolute",
-                top: 0,
-                bottom: 0,
-                left: 0,
-                height: "100%",
-              }}
-              onClick={() =>
-                setIndex((index - 1 + images.length) % images.length)
-              }
-            >
-              <ArrowBackIos />
-            </IconButton>
-            <IconButton
-              sx={{
-                position: "absolute",
-                height: "100%",
-                top: 0,
-                bottom: 0,
-                right: 0,
-              }}
-              onClick={() => setIndex((index + 1) % images.length)}
-            >
-              <ArrowForwardIos />
-            </IconButton>
-          </Box>
-        </>
-      )}
-    </TransformWrapper>
+      <ModalClose
+        sx={{
+          color: "white",
+          zIndex: 10,
+          bgcolor: "rgba(0,0,0,0.5)",
+          "&:hover": { bgcolor: "rgba(0,0,0,0.7)" },
+        }}
+      />
+
+      <IconButton
+        sx={{
+          position: "absolute",
+          left: 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          zIndex: 10,
+          ...controlButtonSx,
+        }}
+        onClick={() => setIndex((index - 1 + images.length) % images.length)}
+      >
+        <ArrowBackIos />
+      </IconButton>
+      <IconButton
+        sx={{
+          position: "absolute",
+          right: 8,
+          top: "50%",
+          transform: "translateY(-50%)",
+          zIndex: 10,
+          ...controlButtonSx,
+        }}
+        onClick={() => setIndex((index + 1) % images.length)}
+      >
+        <ArrowForwardIos />
+      </IconButton>
+    </Box>
   );
 };
 export default ImageWindow;

--- a/frontend/src/components/Images/ImageWindow.tsx
+++ b/frontend/src/components/Images/ImageWindow.tsx
@@ -47,7 +47,7 @@ const ImageWindow: FC<ImageWindowProps> = ({ images, initialId }) => {
       sx={{
         width: "100%",
         height: "100vh",
-        bgcolor: "black",
+        bgcolor: "#1e1e1e",
         position: "relative",
         overflow: "hidden",
       }}

--- a/internal/anime/service_test.go
+++ b/internal/anime/service_test.go
@@ -922,6 +922,23 @@ func TestService_DeriveTagsForAnime(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, derived)
 	})
+
+	t.Run("includes anime-assigned tag with zero images", func(t *testing.T) {
+		animeWithTag, err := svc.Create(ctx, "AnimeWithAssignedTag")
+		require.NoError(t, err)
+
+		// Create a tag assigned directly to the anime via AnimeID
+		animeID := animeWithTag.ID
+		assignedTag := db.Tag{Name: "assigned-char", Category: "character", AnimeID: &animeID}
+		require.NoError(t, db.Create(te.dbClient.Client, &assignedTag))
+
+		derived, err := svc.DeriveTagsForAnime(animeWithTag.ID)
+		require.NoError(t, err)
+		require.Len(t, derived, 1)
+		assert.Equal(t, assignedTag.ID, derived[0].TagID)
+		assert.Equal(t, "assigned-char", derived[0].TagName)
+		assert.Equal(t, uint(0), derived[0].ImageCount)
+	})
 }
 
 func TestService_GetFolderImageIDs(t *testing.T) {

--- a/internal/frontend/image.go
+++ b/internal/frontend/image.go
@@ -2,8 +2,10 @@ package frontend
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/michael-freling/anime-image-viewer/internal/image"
+	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 type ImageService struct {
@@ -22,6 +24,19 @@ func (service *ImageService) ReadImagesByIDs(ctx context.Context, imageIDs []uin
 		return nil, err
 	}
 	return list.ToMap(), nil
+}
+
+func (service *ImageService) OpenImageInOS(ctx context.Context, imageID uint) error {
+	imageFiles, err := service.imageReader.ReadImagesByIDs([]uint{imageID})
+	if err != nil {
+		return fmt.Errorf("ReadImagesByIDs: %w", err)
+	}
+	if len(imageFiles) == 0 {
+		return fmt.Errorf("image not found: %d", imageID)
+	}
+
+	app := application.Get()
+	return app.BrowserOpenFile(imageFiles[0].LocalFilePath)
 }
 
 type Image struct {

--- a/internal/frontend/image_service_test.go
+++ b/internal/frontend/image_service_test.go
@@ -127,3 +127,45 @@ func TestImageService_ReadImagesByIDs_Error(t *testing.T) {
 	_, gotErr := service.ReadImagesByIDs(context.Background(), []uint{11})
 	assert.Error(t, gotErr, "should return error when parent directory is missing from DB")
 }
+
+func TestImageService_OpenImageInOS(t *testing.T) {
+	tester := newTester(t)
+	dbClient := tester.dbClient
+
+	fileBuilder := tester.newFileCreator(t)
+	for _, dir := range []image.Directory{
+		{ID: 1, Name: "Directory 1"},
+	} {
+		fileBuilder.CreateDirectory(dir)
+	}
+	for _, imageFile := range []image.ImageFile{
+		{ID: 11, Name: "image_file_11.jpg", ParentID: 1},
+	} {
+		fileBuilder.CreateImage(imageFile, image.TestImageFileJpeg)
+		fileBuilder.AddImageCreatedAt(imageFile.ID, time.Date(2021, 1, 1, 0, 0, int(imageFile.ID), 0, time.UTC))
+	}
+
+	t.Run("error when ReadImagesByIDs fails", func(t *testing.T) {
+		// Insert the image file into DB but NOT the parent directory,
+		// so ConvertImageFile will fail because the parent directory has ID 0.
+		dbClient.Truncate(t, &db.File{})
+		db.LoadTestData(t, dbClient, []db.File{
+			fileBuilder.BuildDBImageFile(11),
+		})
+
+		service := tester.getImageService()
+		gotErr := service.OpenImageInOS(context.Background(), 11)
+		assert.Error(t, gotErr)
+		assert.Contains(t, gotErr.Error(), "ReadImagesByIDs")
+	})
+
+	t.Run("error when image not found", func(t *testing.T) {
+		// Empty DB so no image is found for the given ID.
+		dbClient.Truncate(t, &db.File{})
+
+		service := tester.getImageService()
+		gotErr := service.OpenImageInOS(context.Background(), 999)
+		assert.Error(t, gotErr)
+		assert.Contains(t, gotErr.Error(), "image not found")
+	})
+}


### PR DESCRIPTION
## Summary
- Fix image viewer to center images in viewport with dark gray background, resolving issues with portrait images stuck at top with white space and zoomed images being clipped
- Configure `react-zoom-pan-pinch` for proper zoom/pan: center on init, double-click toggle, free panning when zoomed, and automatic reset on image navigation
- Add "Open in OS" button that opens images with the system default application via Wails `BrowserOpenFile` API (cross-platform)
- Restyle navigation arrows as compact vertically-centered buttons that don't interfere with pan gestures

🤖 Generated with [Claude Code](https://claude.com/claude-code)