### PR TITLE
feat: add delete images, restore backup config, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,6 @@ Download executables for Windows or Linux from the [release page](https://github
 - Manual backup/restore with optional image inclusion
 - Customizable directories for images, config, logs, and backups
 
-### Experimental
-- ML-based tag suggestions (requires a separate Python server; not included in this repository)
-
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,43 +1,55 @@
-# Anime image viewer
+# Anime Image Viewer
 
 > [!WARNING]
-> This app is still under development and there are a lot of missing features and performance bottlenecks.
-> Please take a backup on your data for safety when you use this app.
+> This app is under active development. Please back up your data before use.
 
-This is a desktop app for browsing anime images.
-Take a look at a next video and get an idea of what you can do by this app!
+A desktop app for organizing and browsing anime image collections. Built with Go (Wails) and React.
 
 [![Watch the Demo](https://img.youtube.com/vi/OculrxRpfJI/hqdefault.jpg)](https://www.youtube.com/embed/OculrxRpfJI)
 
-> The sources of the images in the above Demo,
+> Image sources in the demo:
 > - https://x.com/oshinoko_global/status/1874291958866231761/photo/1
 > - https://x.com/AniTrendz/status/1739087701499150632/photo/1
 
 
-> [!NOTE]
-> Despite this is developed for organizing anime images, currently, there is no feature specific to anime images.
-
-
 ## Download
 
-You can download executable files on Windows or Linux on a [release page](https://github.com/michael-freling/anime-image-viewer/releases).
+Download executables for Windows or Linux from the [release page](https://github.com/michael-freling/anime-image-viewer/releases).
 
 
 ## Features
 
-This app provides a few features to manage anime images more efficiently, including but not limited to followings:
+### Anime Management
+- Browse your collection in a responsive masonry grid with adjustable sizing (XS/S/M/L)
+- Organize anime with hierarchical seasons, parts, and episodes
+- Link anime to [AniList](https://anilist.co) for automatic metadata import (titles, airing info, covers)
+- Import full season chains via BFS traversal of sequel/prequel relationships
 
-1. Manage images under folders
-2. Manage images and folders by tags
-3. Import images with tags included in sidecar XMP files managed by DigiKam
-4. (Experimental) Suggest tags by a ML model
+### Image Organization
+- Tag-based and character-based image organization (separate systems)
+- Multi-image selection via click, Shift+click, Ctrl+click, Ctrl+A, or rubber-band drag
+- Bulk edit tags and characters across selected images
+- Import images with tags from DigiKam XMP sidecar files
+- Delete images with confirmation
 
-A ML model is **NOT** included in this repository, and in order to use suggested tags, at first, you need to upload images using this app and run ML trainings.
-Currently, you need to run a python server by yourself to use this feature.
+### Image Viewer
+- Full-screen overlay with keyboard navigation
+- Zoom and pan with double-click toggle
+- Open images in OS default viewer or reveal in file explorer
 
-Besides, there are missing features and improvements listed in [./docs/TODO.md](), although there is no ETA for each.
+### Search
+- Filter images by anime, tags, and characters
+- Combine include/exclude tag filters
+
+### Backup and Settings
+- Configurable automatic idle backups with retention policies
+- Manual backup/restore with optional image inclusion
+- Customizable directories for images, config, logs, and backups
+
+### Experimental
+- ML-based tag suggestions (requires a separate Python server; not included in this repository)
 
 
 ## Development
 
-Read [./docs/development.md] for a document related to a development.
+See [docs/development.md](./docs/development.md) for development setup and guidelines.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 
 A desktop app for organizing and browsing anime image collections. Built with Go (Wails) and React.
 
-[![Watch the Demo](https://img.youtube.com/vi/OculrxRpfJI/hqdefault.jpg)](https://www.youtube.com/embed/OculrxRpfJI)
-
-> Image sources in the demo:
-> - https://x.com/oshinoko_global/status/1874291958866231761/photo/1
-> - https://x.com/AniTrendz/status/1739087701499150632/photo/1
-
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -3,42 +3,41 @@
 > [!WARNING]
 > This app is under active development. Please back up your data before use.
 
-A desktop app for organizing and browsing anime image collections. Built with Go (Wails) and React.
+A desktop app for organizing and browsing anime image collections.
 
 
 ## Download
 
-Download executables for Windows or Linux from the [release page](https://github.com/michael-freling/anime-image-viewer/releases).
+Download for Windows or Linux from the [release page](https://github.com/michael-freling/anime-image-viewer/releases).
 
 
 ## Features
 
 ### Anime Management
-- Browse your collection in a responsive masonry grid with adjustable sizing (XS/S/M/L)
-- Organize anime with hierarchical seasons, parts, and episodes
-- Link anime to [AniList](https://anilist.co) for automatic metadata import (titles, airing info, covers)
-- Import full season chains via BFS traversal of sequel/prequel relationships
+- Browse your collection in an image grid with adjustable sizing
+- Organize anime with seasons, parts, and episodes
+- Link anime to [AniList](https://anilist.co) to automatically import titles, airing info, and related seasons
 
 ### Image Organization
-- Tag-based and character-based image organization (separate systems)
-- Multi-image selection via click, Shift+click, Ctrl+click, Ctrl+A, or rubber-band drag
-- Bulk edit tags and characters across selected images
-- Import images with tags from DigiKam XMP sidecar files
+- Organize images by tags and characters
+- Select multiple images by clicking, dragging, or keyboard shortcuts
+- Edit tags and characters across many images at once
+- Import images with tags from DigiKam
 - Delete images with confirmation
 
 ### Image Viewer
-- Full-screen overlay with keyboard navigation
-- Zoom and pan with double-click toggle
-- Open images in OS default viewer or reveal in file explorer
+- Full-screen viewer with keyboard navigation
+- Zoom and pan
+- Open images in your default image app or show in file explorer
 
 ### Search
 - Filter images by anime, tags, and characters
-- Combine include/exclude tag filters
+- Combine multiple filters to find specific images
 
 ### Backup and Settings
-- Configurable automatic idle backups with retention policies
-- Manual backup/restore with optional image inclusion
-- Customizable directories for images, config, logs, and backups
+- Automatic backups when the app is idle
+- Manual backup and restore
+- Choose which folders the app uses for images, backups, and settings
 
 
 ## Development

--- a/frontend/__tests__/pages/anime-detail/images-tab.test.tsx
+++ b/frontend/__tests__/pages/anime-detail/images-tab.test.tsx
@@ -70,6 +70,7 @@ jest.mock("masonic", () => {
 const getAnimeDetailsMock = jest.fn();
 const searchImagesByAnimeMock = jest.fn();
 const importImagesMock = jest.fn();
+const deleteImagesMock = jest.fn();
 jest.mock("../../../src/lib/api", () => ({
   __esModule: true,
   AnimeService: {
@@ -80,6 +81,11 @@ jest.mock("../../../src/lib/api", () => ({
   },
   BatchImportImageService: {
     ImportImages: (...args: unknown[]) => importImagesMock(...args),
+  },
+  ImageService: {
+    DeleteImages: (...args: unknown[]) => deleteImagesMock(...args),
+    OpenImageInOS: jest.fn().mockResolvedValue(undefined),
+    ShowImageInExplorer: jest.fn().mockResolvedValue(undefined),
   },
   TagService: {
     GetAll: () => Promise.resolve([]),
@@ -133,6 +139,8 @@ describe("ImagesTab", () => {
     searchImagesByAnimeMock.mockResolvedValue({ images: [] });
     importImagesMock.mockReset();
     importImagesMock.mockResolvedValue([]);
+    deleteImagesMock.mockReset();
+    deleteImagesMock.mockResolvedValue(undefined);
     resetSelectionStore();
     useImportProgressStore.setState({ imports: new Map() });
     capturedOnSelectionCommit = null;
@@ -703,6 +711,130 @@ describe("ImagesTab", () => {
       // Selection should remain unchanged
       expect(useSelectionStore.getState().selectedIds).toEqual(
         new Set([1]),
+      );
+    } finally {
+      unmount();
+    }
+  });
+
+  test("delete button calls DeleteImages after confirmation", async () => {
+    searchImagesByAnimeMock.mockResolvedValue({
+      images: [makeImage(1, "a.png"), makeImage(2, "b.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([1, 2]),
+        lastSelectedId: 2,
+      });
+    });
+
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+
+    const { container, unmount } = renderRoutes(routes, {
+      initialEntries: ["/anime/42/images"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='selection-action-bar']") !== null,
+      );
+      const deleteBtn = container.querySelector(
+        "[data-testid='selection-delete']",
+      ) as HTMLButtonElement;
+      expect(deleteBtn).not.toBeNull();
+      act(() => {
+        deleteBtn.click();
+      });
+      await waitFor(() => deleteImagesMock.mock.calls.length > 0);
+      expect(deleteImagesMock).toHaveBeenCalledWith([1, 2]);
+      expect(window.confirm).toHaveBeenCalled();
+    } finally {
+      window.confirm = originalConfirm;
+      unmount();
+    }
+  });
+
+  test("delete does nothing when user cancels the confirmation", async () => {
+    searchImagesByAnimeMock.mockResolvedValue({
+      images: [makeImage(1, "a.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([1]),
+        lastSelectedId: 1,
+      });
+    });
+
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => false);
+
+    const { container, unmount } = renderRoutes(routes, {
+      initialEntries: ["/anime/42/images"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='selection-action-bar']") !== null,
+      );
+      const deleteBtn = container.querySelector(
+        "[data-testid='selection-delete']",
+      ) as HTMLButtonElement;
+      act(() => {
+        deleteBtn.click();
+      });
+      // Should not have called the API.
+      expect(deleteImagesMock).not.toHaveBeenCalled();
+    } finally {
+      window.confirm = originalConfirm;
+      unmount();
+    }
+  });
+
+  test("image viewer opens on click and can be navigated with Next button", async () => {
+    searchImagesByAnimeMock.mockResolvedValue({
+      images: [makeImage(1, "a.png"), makeImage(2, "b.png")],
+    });
+    const { container, unmount } = renderRoutes(routes, {
+      initialEntries: ["/anime/42/images"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      // Click the first tile to open the viewer.
+      const tile = container.querySelector("[data-file-id='1']") as HTMLElement;
+      act(() => {
+        tile.click();
+      });
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-viewer-overlay']") !== null,
+      );
+      // Click Next to navigate to the second image.
+      const nextBtn = container.querySelector(
+        "[data-testid='image-viewer-next']",
+      ) as HTMLElement;
+      act(() => {
+        nextBtn.click();
+      });
+      // The viewer image should change to the second image.
+      await waitFor(() => {
+        const img = container.querySelector(
+          "[data-testid='image-viewer-image']",
+        ) as HTMLImageElement | null;
+        return img?.alt === "b.png";
+      });
+      // Close the viewer.
+      const closeBtn = container.querySelector(
+        "[data-testid='image-viewer-close']",
+      ) as HTMLElement;
+      act(() => {
+        closeBtn.click();
+      });
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-viewer-overlay']") === null,
       );
     } finally {
       unmount();

--- a/frontend/__tests__/pages/search/index.test.tsx
+++ b/frontend/__tests__/pages/search/index.test.tsx
@@ -31,6 +31,26 @@ jest.mock("@mantine/hooks", () => ({
   useHotkeys: () => undefined,
 }));
 
+// Capture the RubberBandOverlay's callbacks so we can invoke them directly.
+let capturedOnSelectionCommit: ((finalIds: Set<number>, isAdditive: boolean) => void) | null = null;
+let capturedOnSelectionChange: ((ids: Set<number>) => void) | null = null;
+jest.mock("../../../src/components/selection/rubber-band-overlay", () => {
+  const ReactModule = jest.requireActual<typeof import("react")>("react");
+  return {
+    __esModule: true,
+    RubberBandOverlay: (props: {
+      onSelectionCommit: (finalIds: Set<number>, isAdditive: boolean) => void;
+      onSelectionChange: (ids: Set<number>) => void;
+    }) => {
+      capturedOnSelectionCommit = props.onSelectionCommit;
+      capturedOnSelectionChange = props.onSelectionChange;
+      return ReactModule.createElement("div", {
+        "data-testid": "rubber-band-live-region",
+      });
+    },
+  };
+});
+
 // Mock masonic to render all items in jsdom (masonic relies on IntersectionObserver + window scroll).
 jest.mock("masonic", () => {
   const ReactModule = jest.requireActual<typeof import("react")>("react");
@@ -54,6 +74,7 @@ const getAllTagsMock = jest.fn();
 const getAnimeDetailsMock = jest.fn();
 const searchImagesByAnimeMock = jest.fn();
 const getFolderImagesMock = jest.fn();
+const deleteImagesMock = jest.fn();
 
 const getImageTagIDsMock = jest.fn();
 const getImageCharacterIDsMock = jest.fn();
@@ -68,6 +89,9 @@ jest.mock("../../../src/lib/api", () => ({
   },
   CharacterService: {
     GetImageCharacterIDs: (...args: unknown[]) => getImageCharacterIDsMock(...args),
+  },
+  ImageService: {
+    DeleteImages: (...args: unknown[]) => deleteImagesMock(...args),
   },
   SearchService: {
     SearchImages: (...args: unknown[]) => searchImagesMock(...args),
@@ -140,7 +164,11 @@ describe("SearchPage", () => {
     getImageTagIDsMock.mockResolvedValue({});
     getImageCharacterIDsMock.mockReset();
     getImageCharacterIDsMock.mockResolvedValue({});
+    deleteImagesMock.mockReset();
+    deleteImagesMock.mockResolvedValue(undefined);
     resetSelectionStore();
+    capturedOnSelectionCommit = null;
+    capturedOnSelectionChange = null;
   });
 
   test("renders the toolbar with search bar and filters button", async () => {
@@ -1097,6 +1125,327 @@ describe("SearchPage", () => {
         return filterBtn?.textContent?.includes("Filters (2)") ?? false;
       });
     } finally {
+      unmount();
+    }
+  });
+
+  test("closing the image viewer calls handleViewerClose and hides the overlay", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(500, "hero.png"), makeImage(501, "villain.png")],
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      // Wait for the image grid to render.
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      // Click a tile to open the viewer.
+      const tile = container.querySelector(
+        "[data-file-id='500']",
+      ) as HTMLElement;
+      act(() => {
+        tile.click();
+      });
+      // The viewer should open.
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-viewer-overlay']") !==
+          null,
+      );
+      // Click the close button.
+      const closeBtn = container.querySelector(
+        "[data-testid='image-viewer-close']",
+      ) as HTMLElement;
+      act(() => {
+        closeBtn.click();
+      });
+      // The overlay should disappear.
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-viewer-overlay']") ===
+          null,
+      );
+      expect(
+        container.querySelector("[data-testid='image-viewer-overlay']"),
+      ).toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  test("navigating in the image viewer calls handleViewerIndexChange", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(500, "hero.png"), makeImage(501, "villain.png")],
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      // Wait for the image grid to render.
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      // Click the first tile to open the viewer at index 0.
+      const tile = container.querySelector(
+        "[data-file-id='500']",
+      ) as HTMLElement;
+      act(() => {
+        tile.click();
+      });
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='image-viewer-overlay']") !==
+          null,
+      );
+      // Click the "Next" button to navigate to index 1.
+      const nextBtn = container.querySelector(
+        "[data-testid='image-viewer-next']",
+      ) as HTMLElement;
+      act(() => {
+        nextBtn.click();
+      });
+      // The viewer should show the second image now.
+      await waitFor(() => {
+        const img = container.querySelector(
+          "[data-testid='image-viewer-image']",
+        ) as HTMLImageElement | null;
+        return img?.alt?.includes("villain") ?? false;
+      });
+      const img = container.querySelector(
+        "[data-testid='image-viewer-image']",
+      ) as HTMLImageElement;
+      expect(img.alt).toContain("villain");
+    } finally {
+      unmount();
+    }
+  });
+
+  test("Edit button navigates to /images/edit without anime param", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([100]),
+        lastSelectedId: 100,
+      });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='selection-action-bar']") !== null,
+      );
+      // Find and click the Edit button.
+      const editBtn = container.querySelector(
+        "[data-testid='selection-edit']",
+      ) as HTMLButtonElement;
+      expect(editBtn).not.toBeNull();
+      act(() => {
+        editBtn.click();
+      });
+      // The navigation should occur (we just assert the button was clickable
+      // and the handler ran without error; the router navigates away).
+    } finally {
+      unmount();
+    }
+  });
+
+  test("Edit button navigates with anime param when anime filter is active", async () => {
+    getAnimeDetailsMock.mockResolvedValue({
+      anime: { id: 42, name: "Bebop", aniListId: null },
+      tags: [],
+      characters: [],
+      folders: [],
+      folderTree: null,
+      seasons: [],
+    });
+    searchImagesByAnimeMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([100]),
+        lastSelectedId: 100,
+      });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?anime=42&tag=1"],
+    });
+    try {
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='selection-action-bar']") !== null,
+      );
+      // Find and click the Edit button.
+      const editBtn = container.querySelector(
+        "[data-testid='selection-edit']",
+      ) as HTMLButtonElement;
+      expect(editBtn).not.toBeNull();
+      act(() => {
+        editBtn.click();
+      });
+      // The navigation should occur with the anime param.
+    } finally {
+      unmount();
+    }
+  });
+
+  test("rubber band commit with non-empty ids sets selection (non-additive)", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png"), makeImage(101, "beach.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({ selectMode: true });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      expect(capturedOnSelectionCommit).not.toBeNull();
+      // Commit a non-additive selection.
+      act(() => {
+        capturedOnSelectionCommit!(new Set([100, 101]), false);
+      });
+      expect(useSelectionStore.getState().selectedIds).toEqual(new Set([100, 101]));
+    } finally {
+      unmount();
+    }
+  });
+
+  test("rubber band commit with isAdditive merges into existing selection", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png"), makeImage(101, "beach.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([100]),
+        lastSelectedId: 100,
+      });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      expect(capturedOnSelectionCommit).not.toBeNull();
+      // Commit an additive selection.
+      act(() => {
+        capturedOnSelectionCommit!(new Set([101]), true);
+      });
+      expect(useSelectionStore.getState().selectedIds).toEqual(new Set([100, 101]));
+    } finally {
+      unmount();
+    }
+  });
+
+  test("rubber band commit with empty ids resets pending without changing selection", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({ selectMode: true });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      expect(capturedOnSelectionCommit).not.toBeNull();
+      // Commit with empty set.
+      act(() => {
+        capturedOnSelectionCommit!(new Set(), false);
+      });
+      // Selection should remain empty.
+      expect(useSelectionStore.getState().selectedIds.size).toBe(0);
+    } finally {
+      unmount();
+    }
+  });
+
+  test("rubber band change updates pending ids", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png")],
+    });
+    act(() => {
+      useSelectionStore.setState({ selectMode: true });
+    });
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () => container.querySelector("[data-testid='image-grid']") !== null,
+      );
+      expect(capturedOnSelectionChange).not.toBeNull();
+      // Trigger change - the pending ids don't affect the store directly.
+      act(() => {
+        capturedOnSelectionChange!(new Set([100]));
+      });
+      // The selection store's selectedIds should NOT have changed.
+      expect(useSelectionStore.getState().selectedIds.size).toBe(0);
+    } finally {
+      unmount();
+    }
+  });
+
+  test("delete button calls DeleteImages after confirmation", async () => {
+    searchImagesMock.mockResolvedValue({
+      images: [makeImage(100, "sunset.png"), makeImage(101, "beach.png")],
+    });
+    // Enter select mode with images selected.
+    act(() => {
+      useSelectionStore.setState({
+        selectMode: true,
+        selectedIds: new Set([100, 101]),
+        lastSelectedId: 101,
+      });
+    });
+
+    // Mock window.confirm to return true.
+    const originalConfirm = window.confirm;
+    window.confirm = jest.fn(() => true);
+
+    const { container, unmount } = renderWithClient(<SearchPage />, {
+      routerInitialEntries: ["/search?tag=1"],
+    });
+    try {
+      await waitFor(
+        () =>
+          container.querySelector("[data-testid='selection-action-bar']") !== null,
+      );
+      // Find the Delete button in the action bar.
+      const deleteBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) =>
+        (b.textContent ?? "").toLowerCase().includes("delete"),
+      ) as HTMLButtonElement | undefined;
+      expect(deleteBtn).toBeDefined();
+      act(() => {
+        deleteBtn!.click();
+      });
+
+      await waitFor(() => deleteImagesMock.mock.calls.length > 0);
+      expect(deleteImagesMock).toHaveBeenCalledWith([100, 101]);
+      expect(window.confirm).toHaveBeenCalled();
+    } finally {
+      window.confirm = originalConfirm;
       unmount();
     }
   });

--- a/frontend/__tests__/pages/settings/sections/backup-section.test.tsx
+++ b/frontend/__tests__/pages/settings/sections/backup-section.test.tsx
@@ -609,4 +609,272 @@ describe("BackupSection", () => {
       r.unmount();
     }
   });
+
+  test("renders backup configuration form with current values", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-config']") !== null,
+      );
+      const retentionInput = r.container.querySelector(
+        "[data-testid='backup-retention-count']",
+      ) as HTMLInputElement;
+      expect(retentionInput).not.toBeNull();
+      expect(retentionInput.value).toBe("5");
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("saving backup config calls UpdateConfig with merged values", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    updateConfigMock.mockResolvedValue(undefined);
+
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-config']") !== null,
+      );
+      const retentionInput = r.container.querySelector(
+        "[data-testid='backup-retention-count']",
+      ) as HTMLInputElement;
+
+      // Change retention count to 10
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      await act(async () => {
+        setter.call(retentionInput, "10");
+        retentionInput.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+      // Click save
+      const saveBtn = r.container.querySelector(
+        "[data-testid='save-backup-config']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => updateConfigMock.mock.calls.length > 0);
+      expect(updateConfigMock).toHaveBeenCalledWith({
+        ...sampleConfig,
+        retentionCount: 10,
+      });
+      await waitFor(() => toastSuccess.mock.calls.length > 0);
+      expect(toastSuccess).toHaveBeenCalledWith("Backup configuration saved");
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("save button is disabled when no changes", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='save-backup-config']") !== null,
+      );
+      const saveBtn = r.container.querySelector(
+        "[data-testid='save-backup-config']",
+      ) as HTMLButtonElement;
+      expect(saveBtn.disabled).toBe(true);
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("toggling idle backup enabled updates the switch", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-idle-enabled']") !== null,
+      );
+      // The idle minutes input should be disabled initially (idleBackupEnabled = false)
+      const idleMinutesInput = r.container.querySelector(
+        "[data-testid='backup-idle-minutes']",
+      ) as HTMLInputElement;
+      expect(idleMinutesInput.disabled).toBe(true);
+
+      // Click the hidden input inside the switch to toggle it
+      const switchRoot = r.container.querySelector(
+        "[data-testid='backup-idle-enabled']",
+      ) as HTMLElement;
+      const hiddenInput = switchRoot.querySelector("input") as HTMLInputElement;
+      await act(async () => {
+        hiddenInput.click();
+      });
+
+      // After toggling, idle minutes input should be enabled
+      await waitFor(() => {
+        const input = r.container.querySelector(
+          "[data-testid='backup-idle-minutes']",
+        ) as HTMLInputElement;
+        return !input.disabled;
+      });
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("save backup config failure shows error toast", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    updateConfigMock.mockRejectedValue(new Error("write fail"));
+
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-config']") !== null,
+      );
+      // Change a field to enable save
+      const retentionInput = r.container.querySelector(
+        "[data-testid='backup-retention-count']",
+      ) as HTMLInputElement;
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      await act(async () => {
+        setter.call(retentionInput, "10");
+        retentionInput.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+      // Click save
+      const saveBtn = r.container.querySelector(
+        "[data-testid='save-backup-config']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => toastError.mock.calls.length > 0);
+      expect(toastError).toHaveBeenCalledWith(
+        "Couldn't save backup configuration",
+        "write fail",
+      );
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("toggling idle include images updates the switch and saves correctly", async () => {
+    // Start with idle backup enabled so the include-images switch is not disabled.
+    getConfigMock.mockReset();
+    getConfigMock.mockResolvedValue({ ...sampleConfig, idleBackupEnabled: true });
+    listBackupsMock.mockResolvedValue([]);
+    updateConfigMock.mockResolvedValue(undefined);
+
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-idle-include-images']") !== null,
+      );
+      // The idle include images switch should be enabled (not disabled).
+      const switchRoot = r.container.querySelector(
+        "[data-testid='backup-idle-include-images']",
+      ) as HTMLElement;
+      const hiddenInput = switchRoot.querySelector("input") as HTMLInputElement;
+      expect(hiddenInput.disabled).toBe(false);
+
+      // Toggle it on.
+      await act(async () => {
+        hiddenInput.click();
+      });
+
+      // Save the config.
+      const saveBtn = r.container.querySelector(
+        "[data-testid='save-backup-config']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => updateConfigMock.mock.calls.length > 0);
+      expect(updateConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({ idleBackupIncludeImages: true }),
+      );
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("idle minutes input change updates draft", async () => {
+    // Start with idle backup enabled so the minutes input is not disabled.
+    getConfigMock.mockReset();
+    getConfigMock.mockResolvedValue({ ...sampleConfig, idleBackupEnabled: true });
+    listBackupsMock.mockResolvedValue([]);
+    updateConfigMock.mockResolvedValue(undefined);
+
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-idle-minutes']") !== null,
+      );
+      const idleMinutesInput = r.container.querySelector(
+        "[data-testid='backup-idle-minutes']",
+      ) as HTMLInputElement;
+      expect(idleMinutesInput.disabled).toBe(false);
+
+      // Change the idle minutes value.
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )!.set!;
+      await act(async () => {
+        setter.call(idleMinutesInput, "30");
+        idleMinutesInput.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+      // Save the config.
+      const saveBtn = r.container.querySelector(
+        "[data-testid='save-backup-config']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        saveBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => updateConfigMock.mock.calls.length > 0);
+      expect(updateConfigMock).toHaveBeenCalledWith(
+        expect.objectContaining({ idleMinutes: 30 }),
+      );
+    } finally {
+      r.unmount();
+    }
+  });
+
+  test("include images toggle for manual backup", async () => {
+    listBackupsMock.mockResolvedValue([]);
+    createBackupMock.mockResolvedValue("/backup/new.tar.gz");
+
+    const r = renderWithClient(<BackupSection />);
+    try {
+      await waitFor(
+        () => r.container.querySelector("[data-testid='backup-include-images']") !== null,
+      );
+      // Toggle the include images switch
+      const switchRoot = r.container.querySelector(
+        "[data-testid='backup-include-images']",
+      ) as HTMLElement;
+      const hiddenInput = switchRoot.querySelector("input") as HTMLInputElement;
+      await act(async () => {
+        hiddenInput.click();
+      });
+
+      // Click Create Backup
+      const createBtn = r.container.querySelector(
+        "[data-testid='create-backup']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        createBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+
+      await waitFor(() => createBackupMock.mock.calls.length > 0);
+      expect(createBackupMock).toHaveBeenCalledWith(true, "");
+    } finally {
+      r.unmount();
+    }
+  });
 });

--- a/frontend/__tests__/pages/tags/tag-form.test.tsx
+++ b/frontend/__tests__/pages/tags/tag-form.test.tsx
@@ -174,6 +174,26 @@ describe("TagForm", () => {
     r.unmount();
   });
 
+  test("clearing parent select emits null parentId", () => {
+    const onChange = jest.fn();
+    const r = render(
+      createElement(TagForm, {
+        values: { ...BASE_VALUES, parentId: 11 },
+        onChange,
+        parentOptions: PARENT_OPTIONS,
+        onCancel: jest.fn(),
+        submitLabel: "Create",
+      }),
+    );
+    const select = r.container.querySelector<HTMLSelectElement>(
+      "[data-testid='tag-form-parent']",
+    )!;
+    // Select the "(none)" option which has value "".
+    setSelectValue(select, "");
+    expect(onChange).toHaveBeenLastCalledWith({ ...BASE_VALUES, parentId: null });
+    r.unmount();
+  });
+
   test("parent select is disabled when no options are provided", () => {
     const r = render(
       createElement(TagForm, {

--- a/frontend/src/components/selection/selection-action-bar.tsx
+++ b/frontend/src/components/selection/selection-action-bar.tsx
@@ -38,6 +38,8 @@ export interface SelectionActionBarProps {
   onEditTags?: () => void;
   /** Opens the unified Image Editor (seasons + characters + tags). */
   onEdit?: () => void;
+  /** Deletes the selected images (caller should confirm before invoking). */
+  onDelete?: () => void;
 }
 
 /**
@@ -61,6 +63,7 @@ export function SelectionActionBar({
   totalVisible,
   onEditTags,
   onEdit,
+  onDelete,
 }: SelectionActionBarProps): ReactElement | null {
   const selectMode = useSelectionStore((s) => s.selectMode);
   const selectedIds = useSelectionStore((s) => s.selectedIds);
@@ -159,6 +162,19 @@ export function SelectionActionBar({
               aria-label="Edit tags for selected images"
             >
               Edit Tags
+            </Button>
+          ) : null}
+
+          {onDelete ? (
+            <Button
+              size="xs"
+              colorPalette="red"
+              onClick={onDelete}
+              disabled={count === 0}
+              data-testid="selection-delete"
+              aria-label="Delete selected images"
+            >
+              Delete
             </Button>
           ) : null}
 

--- a/frontend/src/hooks/use-image-mutations.ts
+++ b/frontend/src/hooks/use-image-mutations.ts
@@ -1,0 +1,35 @@
+/**
+ * Image mutation hooks (delete, etc.).
+ *
+ * Follows the same pattern as `use-season-mutations.ts`: calls the Wails
+ * binding then invalidates relevant React Query caches.
+ */
+import {
+  useMutation,
+  UseMutationResult,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { ImageService } from "../lib/api";
+import { qk } from "../lib/query-keys";
+
+export interface DeleteImagesVariables {
+  imageIds: number[];
+}
+
+export function useDeleteImages(): UseMutationResult<
+  void,
+  Error,
+  DeleteImagesVariables
+> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, DeleteImagesVariables>({
+    mutationFn: async ({ imageIds }) => {
+      await ImageService.DeleteImages(imageIds);
+    },
+    onSuccess: () => {
+      // Broad invalidation since deleted images could appear in any anime/search view.
+      void queryClient.invalidateQueries({ queryKey: qk.anime.all });
+      void queryClient.invalidateQueries({ queryKey: ["search"] });
+    },
+  });
+}

--- a/frontend/src/pages/anime-detail/images-tab.tsx
+++ b/frontend/src/pages/anime-detail/images-tab.tsx
@@ -25,6 +25,7 @@ import { RubberBandOverlay } from "../../components/selection/rubber-band-overla
 import { SelectionActionBar } from "../../components/selection/selection-action-bar";
 import { useAnimeDetail } from "../../hooks/use-anime-detail";
 import { useAnimeImages } from "../../hooks/use-anime-images";
+import { useDeleteImages } from "../../hooks/use-image-mutations";
 import { useImageImport } from "../../hooks/use-image-import";
 import { useImageSelection } from "../../hooks/use-image-selection";
 import { gridSizeColumnWidth } from "../../lib/constants";
@@ -74,6 +75,24 @@ export function ImagesTab(): JSX.Element {
   const gridSize = useUIStore((s) => s.gridSize);
 
   const { importImages } = useImageImport();
+  const deleteImagesMutation = useDeleteImages();
+
+  const handleDelete = useCallback(() => {
+    const ids = Array.from(useSelectionStore.getState().selectedIds);
+    if (ids.length === 0) return;
+    const confirmed = window.confirm(
+      `Delete ${ids.length} image${ids.length > 1 ? "s" : ""}? This cannot be undone.`,
+    );
+    if (!confirmed) return;
+    deleteImagesMutation.mutate(
+      { imageIds: ids },
+      {
+        onSuccess: () => {
+          useSelectionStore.getState().clearSelection();
+        },
+      },
+    );
+  }, [deleteImagesMutation]);
 
   const handleUpload = useCallback(async () => {
     const folderId = detailQuery.data?.folders?.[0]?.id;
@@ -149,6 +168,7 @@ export function ImagesTab(): JSX.Element {
         visibleIds={visibleIds}
         totalVisible={images.length}
         onEdit={() => navigate(`/images/edit?anime=${animeId}`)}
+        onDelete={handleDelete}
       />
 
       {/* Toolbar: Search + Upload */}

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -44,6 +44,7 @@ import { Collapsible } from "../../components/ui/collapsible";
 import { RubberBandOverlay } from "../../components/selection/rubber-band-overlay";
 import { SelectionActionBar } from "../../components/selection/selection-action-bar";
 import { useAnimeDetail } from "../../hooks/use-anime-detail";
+import { useDeleteImages } from "../../hooks/use-image-mutations";
 import { useImageSelection } from "../../hooks/use-image-selection";
 import { useSearchImages } from "../../hooks/use-search-images";
 import { useTags } from "../../hooks/use-tags";
@@ -312,6 +313,25 @@ export function SearchPage(): JSX.Element {
     [],
   );
 
+  const deleteImagesMutation = useDeleteImages();
+
+  const handleDelete = useCallback(() => {
+    const ids = Array.from(useSelectionStore.getState().selectedIds);
+    if (ids.length === 0) return;
+    const confirmed = window.confirm(
+      `Delete ${ids.length} image${ids.length > 1 ? "s" : ""}? This cannot be undone.`,
+    );
+    if (!confirmed) return;
+    deleteImagesMutation.mutate(
+      { imageIds: ids },
+      {
+        onSuccess: () => {
+          useSelectionStore.getState().clearSelection();
+        },
+      },
+    );
+  }, [deleteImagesMutation]);
+
   const isEmpty = isEmptyFilterState(urlState);
   const isLoading = searchQuery.isLoading && !searchQuery.data;
   const hasError = searchQuery.isError;
@@ -436,6 +456,7 @@ export function SearchPage(): JSX.Element {
                 : "/images/edit",
             )
           }
+          onDelete={handleDelete}
         />
       )}
 

--- a/frontend/src/pages/settings/sections/backup-section.tsx
+++ b/frontend/src/pages/settings/sections/backup-section.tsx
@@ -20,9 +20,9 @@
  *   - `EmptyState` when the list is empty.
  *   - `ErrorAlert` with retry on query error.
  */
-import { Box, Button, Stack, Text } from "@chakra-ui/react";
+import { Box, Button, Input, Stack, Switch, Text } from "@chakra-ui/react";
 import { Archive, Database } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { EmptyState } from "../../../components/shared/empty-state";
 import { ErrorAlert } from "../../../components/shared/error-alert";
@@ -35,8 +35,8 @@ import {
   useDeleteBackup,
   useRestoreBackup,
 } from "../../../hooks/use-backup";
-import { useConfig } from "../../../hooks/use-config";
-import type { BackupInfo } from "../../../lib/api";
+import { useConfig, useUpdateConfig } from "../../../hooks/use-config";
+import type { BackupInfo, ConfigSettings } from "../../../lib/api";
 
 /**
  * Format an ISO 8601 timestamp as a locale-friendly datetime string.
@@ -55,8 +55,26 @@ function formatBackupDate(iso: string): string {
   });
 }
 
+/** The subset of ConfigSettings that this section manages. */
+interface BackupConfigDraft {
+  retentionCount: number;
+  idleBackupEnabled: boolean;
+  idleBackupIncludeImages: boolean;
+  idleMinutes: number;
+}
+
+function extractBackupDraft(config: ConfigSettings): BackupConfigDraft {
+  return {
+    retentionCount: config.retentionCount,
+    idleBackupEnabled: config.idleBackupEnabled,
+    idleBackupIncludeImages: config.idleBackupIncludeImages,
+    idleMinutes: config.idleMinutes,
+  };
+}
+
 export function BackupSection(): JSX.Element {
   const configQuery = useConfig();
+  const updateConfig = useUpdateConfig();
   const backupListQuery = useBackupList();
   const createBackup = useCreateBackup();
   const restoreBackup = useRestoreBackup();
@@ -64,14 +82,22 @@ export function BackupSection(): JSX.Element {
 
   const [restoreTarget, setRestoreTarget] = useState<BackupInfo | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<BackupInfo | null>(null);
+  const [draft, setDraft] = useState<BackupConfigDraft | null>(null);
+  const [includeImagesInManual, setIncludeImagesInManual] = useState(false);
+
+  // Sync the draft when the server data loads or changes.
+  useEffect(() => {
+    if (configQuery.data) {
+      setDraft(extractBackupDraft(configQuery.data));
+    }
+  }, [configQuery.data]);
 
   const destination = configQuery.data?.backupDirectory ?? "";
 
   const handleCreate = async () => {
     try {
       const path = await createBackup.mutateAsync({
-        includeImages: false,
-        // Empty string means "use the configured default directory".
+        includeImages: includeImagesInManual,
         targetDir: "",
       });
       toast.success("Backup created", path);
@@ -234,6 +260,24 @@ export function BackupSection(): JSX.Element {
           >
             {destination || "(default)"}
           </Box>
+          <Switch.Root
+            checked={includeImagesInManual}
+            onCheckedChange={(details) =>
+              setIncludeImagesInManual(details.checked)
+            }
+            size="sm"
+            data-testid="backup-include-images"
+          >
+            <Switch.HiddenInput />
+            <Switch.Control>
+              <Switch.Thumb />
+            </Switch.Control>
+            <Switch.Label>
+              <Text fontSize="xs" color="fg.secondary">
+                Include images
+              </Text>
+            </Switch.Label>
+          </Switch.Root>
           <Button
             type="button"
             size="sm"
@@ -251,6 +295,15 @@ export function BackupSection(): JSX.Element {
           </Button>
         </Stack>
       </Stack>
+
+      {draft && (
+        <BackupConfigForm
+          draft={draft}
+          setDraft={setDraft}
+          configQuery={configQuery}
+          updateConfig={updateConfig}
+        />
+      )}
 
       <Stack gap="2">
         <Text fontSize="sm" fontWeight="600" color="fg">
@@ -286,6 +339,167 @@ export function BackupSection(): JSX.Element {
         confirmLabel="Delete"
         variant="danger"
       />
+    </Stack>
+  );
+}
+
+/** Sub-component: Backup Configuration form */
+function BackupConfigForm({
+  draft,
+  setDraft,
+  configQuery,
+  updateConfig,
+}: {
+  draft: BackupConfigDraft;
+  setDraft: (d: BackupConfigDraft) => void;
+  configQuery: ReturnType<typeof useConfig>;
+  updateConfig: ReturnType<typeof useUpdateConfig>;
+}): JSX.Element {
+  const isDirty =
+    configQuery.data !== undefined &&
+    (draft.retentionCount !== configQuery.data.retentionCount ||
+      draft.idleBackupEnabled !== configQuery.data.idleBackupEnabled ||
+      draft.idleBackupIncludeImages !==
+        configQuery.data.idleBackupIncludeImages ||
+      draft.idleMinutes !== configQuery.data.idleMinutes);
+
+  const handleSave = async () => {
+    if (!configQuery.data) return;
+    try {
+      await updateConfig.mutateAsync({
+        ...configQuery.data,
+        ...draft,
+      });
+      toast.success("Backup configuration saved");
+    } catch (err) {
+      toast.error(
+        "Couldn't save backup configuration",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  };
+
+  return (
+    <Stack gap="3" data-testid="backup-config">
+      <Text fontSize="sm" fontWeight="600" color="fg">
+        Backup Configuration
+      </Text>
+
+      <Stack gap="3">
+        {/* Retention Count */}
+        <Box>
+          <Text fontSize="sm" color="fg.secondary" mb="1">
+            Retention Count
+          </Text>
+          <Input
+            type="number"
+            size="sm"
+            min={1}
+            value={draft.retentionCount}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                retentionCount: Math.max(1, parseInt(e.target.value, 10) || 1),
+              })
+            }
+            maxWidth="120px"
+            data-testid="backup-retention-count"
+          />
+          <Text fontSize="xs" color="fg.muted" mt="1">
+            How many backups to keep before older ones are removed.
+          </Text>
+        </Box>
+
+        {/* Idle Backup Enabled */}
+        <Stack direction="row" align="center" gap="3">
+          <Switch.Root
+            checked={draft.idleBackupEnabled}
+            onCheckedChange={(details) =>
+              setDraft({ ...draft, idleBackupEnabled: details.checked })
+            }
+            data-testid="backup-idle-enabled"
+          >
+            <Switch.HiddenInput />
+            <Switch.Control>
+              <Switch.Thumb />
+            </Switch.Control>
+            <Switch.Label>
+              <Text fontSize="sm" color="fg.secondary">
+                Enable automatic idle backups
+              </Text>
+            </Switch.Label>
+          </Switch.Root>
+        </Stack>
+
+        {/* Idle Minutes */}
+        <Box opacity={draft.idleBackupEnabled ? 1 : 0.5}>
+          <Text fontSize="sm" color="fg.secondary" mb="1">
+            Idle Minutes
+          </Text>
+          <Input
+            type="number"
+            size="sm"
+            min={1}
+            value={draft.idleMinutes}
+            onChange={(e) =>
+              setDraft({
+                ...draft,
+                idleMinutes: Math.max(1, parseInt(e.target.value, 10) || 1),
+              })
+            }
+            disabled={!draft.idleBackupEnabled}
+            maxWidth="120px"
+            data-testid="backup-idle-minutes"
+          />
+          <Text fontSize="xs" color="fg.muted" mt="1">
+            Minutes of idle time before an automatic backup triggers.
+          </Text>
+        </Box>
+
+        {/* Include Images */}
+        <Stack
+          direction="row"
+          align="center"
+          gap="3"
+          opacity={draft.idleBackupEnabled ? 1 : 0.5}
+        >
+          <Switch.Root
+            checked={draft.idleBackupIncludeImages}
+            onCheckedChange={(details) =>
+              setDraft({ ...draft, idleBackupIncludeImages: details.checked })
+            }
+            disabled={!draft.idleBackupEnabled}
+            data-testid="backup-idle-include-images"
+          >
+            <Switch.HiddenInput />
+            <Switch.Control>
+              <Switch.Thumb />
+            </Switch.Control>
+            <Switch.Label>
+              <Text fontSize="sm" color="fg.secondary">
+                Include images in idle backups
+              </Text>
+            </Switch.Label>
+          </Switch.Root>
+        </Stack>
+      </Stack>
+
+      <Stack direction="row" gap="2" pt="1">
+        <Button
+          type="button"
+          size="sm"
+          bg="primary"
+          color="bg.surface"
+          _hover={{ bg: "primary.hover" }}
+          onClick={handleSave}
+          disabled={!isDirty || updateConfig.isPending}
+          loading={updateConfig.isPending}
+          loadingText="Saving"
+          data-testid="save-backup-config"
+        >
+          Save
+        </Button>
+      </Stack>
     </Stack>
   );
 }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1231,3 +1231,16 @@ func TestRestore_ConfigDirectoryCreation(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "fake-sqlite-database-content", string(content))
 }
+
+func TestHasRecentBackup_NonExistentDirectory(t *testing.T) {
+	conf := newTestConfig(t)
+	logger := newTestLogger()
+
+	// Point to a non-existent directory so os.ReadDir returns os.IsNotExist.
+	conf.Backup.BackupDirectory = filepath.Join(t.TempDir(), "does-not-exist")
+
+	svc := NewBackupService(logger, conf)
+	hasRecent, err := svc.HasRecentBackup(24 * time.Hour)
+	require.NoError(t, err)
+	assert.False(t, hasRecent, "should return false when backup directory does not exist")
+}

--- a/internal/frontend/image.go
+++ b/internal/frontend/image.go
@@ -3,18 +3,23 @@ package frontend
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
 
+	"github.com/michael-freling/anime-image-viewer/internal/db"
 	"github.com/michael-freling/anime-image-viewer/internal/image"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
 type ImageService struct {
 	imageReader *image.Reader
+	dbClient    *db.Client
 }
 
-func NewImageService(imageReader *image.Reader) *ImageService {
+func NewImageService(imageReader *image.Reader, dbClient *db.Client) *ImageService {
 	return &ImageService{
 		imageReader: imageReader,
+		dbClient:    dbClient,
 	}
 }
 
@@ -52,6 +57,58 @@ func (service *ImageService) ShowImageInExplorer(ctx context.Context, imageID ui
 	}
 
 	return showInExplorer(imageFiles[0].LocalFilePath)
+}
+
+// DeleteImages removes images from the database and from disk.
+// It deletes all associated tag and character links within a transaction,
+// then removes the file records, and finally deletes the physical files
+// from disk (best-effort: missing files are logged and skipped).
+func (service *ImageService) DeleteImages(ctx context.Context, imageIDs []uint) error {
+	if len(imageIDs) == 0 {
+		return nil
+	}
+
+	// Resolve file paths before deleting DB records. This is best-effort:
+	// if the reader fails (e.g. files already missing from disk), we still
+	// proceed with the DB deletion and skip disk cleanup.
+	imageFiles, err := service.imageReader.ReadImagesByIDs(imageIDs)
+	if err != nil {
+		slog.Warn("ReadImagesByIDs failed during delete; will skip disk cleanup",
+			"error", err,
+		)
+		imageFiles = nil
+	}
+
+	// Delete DB records in a transaction.
+	if err := db.NewTransaction(ctx, service.dbClient, func(txCtx context.Context) error {
+		if err := service.dbClient.FileTag().DeleteByFileIDs(txCtx, imageIDs); err != nil {
+			return fmt.Errorf("DeleteByFileIDs (tags): %w", err)
+		}
+		if err := service.dbClient.FileCharacter().DeleteByFileIDs(txCtx, imageIDs); err != nil {
+			return fmt.Errorf("DeleteByFileIDs (characters): %w", err)
+		}
+		if err := service.dbClient.File().DeleteByIDs(txCtx, imageIDs); err != nil {
+			return fmt.Errorf("DeleteByIDs: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("transaction: %w", err)
+	}
+
+	// Delete physical files (best-effort after successful DB transaction).
+	for _, imgFile := range imageFiles {
+		if imgFile.LocalFilePath == "" {
+			continue
+		}
+		if err := os.Remove(imgFile.LocalFilePath); err != nil && !os.IsNotExist(err) {
+			slog.Warn("failed to delete image file from disk",
+				"path", imgFile.LocalFilePath,
+				"error", err,
+			)
+		}
+	}
+
+	return nil
 }
 
 type Image struct {

--- a/internal/frontend/image_service_test.go
+++ b/internal/frontend/image_service_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (tester tester) getImageService() *ImageService {
-	return NewImageService(tester.getFileReader())
+	return NewImageService(tester.getFileReader(), tester.dbClient.Client)
 }
 
 func TestImageService_ReadImagesByIDs(t *testing.T) {
@@ -93,7 +93,7 @@ func TestImageService_ReadImagesByIDs(t *testing.T) {
 
 func TestNewImageService(t *testing.T) {
 	tester := newTester(t)
-	service := NewImageService(tester.getFileReader())
+	service := NewImageService(tester.getFileReader(), tester.dbClient.Client)
 	assert.NotNil(t, service)
 	assert.NotNil(t, service.imageReader)
 }
@@ -225,5 +225,85 @@ func TestImageService_OpenImageInOS(t *testing.T) {
 		gotErr := service.OpenImageInOS(context.Background(), 999)
 		assert.Error(t, gotErr)
 		assert.Contains(t, gotErr.Error(), "image not found")
+	})
+}
+
+func TestImageService_DeleteImages(t *testing.T) {
+	tester := newTester(t)
+	dbClient := tester.dbClient
+
+	fileBuilder := tester.newFileCreator(t)
+	for _, dir := range []image.Directory{
+		{ID: 1, Name: "Directory 1"},
+	} {
+		fileBuilder.CreateDirectory(dir)
+	}
+	for _, imageFile := range []image.ImageFile{
+		{ID: 11, Name: "image_file_11.jpg", ParentID: 1},
+		{ID: 12, Name: "image_file_12.png", ParentID: 1},
+	} {
+		fileBuilder.CreateImage(imageFile, image.TestImageFileJpeg)
+		fileBuilder.AddImageCreatedAt(imageFile.ID, time.Date(2021, 1, 1, 0, 0, int(imageFile.ID), 0, time.UTC))
+	}
+
+	t.Run("deletes images from DB and disk", func(t *testing.T) {
+		dbClient.Truncate(t, &db.File{}, &db.FileTag{}, &db.FileCharacter{})
+		db.LoadTestData(t, dbClient, []db.File{
+			fileBuilder.BuildDBDirectory(1),
+			fileBuilder.BuildDBImageFile(11),
+			fileBuilder.BuildDBImageFile(12),
+		})
+		db.LoadTestData(t, dbClient, []db.FileTag{
+			{TagID: 100, FileID: 11, AddedBy: db.FileTagAddedByUser},
+			{TagID: 100, FileID: 12, AddedBy: db.FileTagAddedByUser},
+		})
+		db.LoadTestData(t, dbClient, []db.FileCharacter{
+			{CharacterID: 200, FileID: 11, AddedBy: db.FileTagAddedByUser},
+		})
+
+		service := tester.getImageService()
+		err := service.DeleteImages(context.Background(), []uint{11, 12})
+		require.NoError(t, err)
+
+		// Verify files are removed from DB.
+		remainingFiles, err := dbClient.Client.File().FindImageFilesByIDs([]uint{11, 12})
+		require.NoError(t, err)
+		assert.Empty(t, remainingFiles)
+
+		// Verify tag associations are removed.
+		remainingTags, err := dbClient.Client.FileTag().FindAllByFileID([]uint{11, 12})
+		require.NoError(t, err)
+		assert.Empty(t, remainingTags)
+
+		// Verify character associations are removed.
+		remainingChars, err := dbClient.Client.FileCharacter().FindByFileIDs([]uint{11, 12})
+		require.NoError(t, err)
+		assert.Empty(t, remainingChars)
+	})
+
+	t.Run("no error for empty IDs", func(t *testing.T) {
+		service := tester.getImageService()
+		err := service.DeleteImages(context.Background(), []uint{})
+		assert.NoError(t, err)
+	})
+
+	t.Run("no error when file already missing from disk", func(t *testing.T) {
+		dbClient.Truncate(t, &db.File{}, &db.FileTag{}, &db.FileCharacter{})
+		// Insert the DB record but do NOT recreate the physical file on disk.
+		// The first sub-test already deleted it; this tests that DeleteImages
+		// gracefully handles the case where ReadImagesByIDs fails.
+		db.LoadTestData(t, dbClient, []db.File{
+			fileBuilder.BuildDBDirectory(1),
+			fileBuilder.BuildDBImageFile(11),
+		})
+
+		service := tester.getImageService()
+		err := service.DeleteImages(context.Background(), []uint{11})
+		assert.NoError(t, err)
+
+		// Verify file is removed from DB.
+		remainingFiles, err := dbClient.Client.File().FindImageFilesByIDs([]uint{11})
+		require.NoError(t, err)
+		assert.Empty(t, remainingFiles)
 	})
 }

--- a/internal/frontend/image_service_test.go
+++ b/internal/frontend/image_service_test.go
@@ -2,6 +2,8 @@ package frontend
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -291,7 +293,7 @@ func TestImageService_DeleteImages(t *testing.T) {
 		dbClient.Truncate(t, &db.File{}, &db.FileTag{}, &db.FileCharacter{})
 		// Insert the DB record but do NOT recreate the physical file on disk.
 		// The first sub-test already deleted it; this tests that DeleteImages
-		// gracefully handles the case where ReadImagesByIDs fails.
+		// gracefully handles the case where the physical file is gone.
 		db.LoadTestData(t, dbClient, []db.File{
 			fileBuilder.BuildDBDirectory(1),
 			fileBuilder.BuildDBImageFile(11),
@@ -303,6 +305,59 @@ func TestImageService_DeleteImages(t *testing.T) {
 
 		// Verify file is removed from DB.
 		remainingFiles, err := dbClient.Client.File().FindImageFilesByIDs([]uint{11})
+		require.NoError(t, err)
+		assert.Empty(t, remainingFiles)
+	})
+
+	t.Run("proceeds with DB delete when ReadImagesByIDs fails", func(t *testing.T) {
+		dbClient.Truncate(t, &db.File{}, &db.FileTag{}, &db.FileCharacter{})
+		// Insert the image file WITHOUT the parent directory so that
+		// ReadImagesByIDs fails (ConvertImageFile needs a valid parent).
+		// DeleteImages should still delete the DB records and skip disk cleanup.
+		db.LoadTestData(t, dbClient, []db.File{
+			fileBuilder.BuildDBImageFile(11),
+		})
+
+		service := tester.getImageService()
+		err := service.DeleteImages(context.Background(), []uint{11})
+		assert.NoError(t, err)
+
+		// Verify file is removed from DB despite ReadImagesByIDs failing.
+		remainingFiles, err := dbClient.Client.File().FindImageFilesByIDs([]uint{11})
+		require.NoError(t, err)
+		assert.Empty(t, remainingFiles)
+	})
+
+	t.Run("logs warning when os.Remove fails with permission error", func(t *testing.T) {
+		// Use a fresh tester with its own temp dir so file paths are clean.
+		tester2 := newTester(t)
+		dbClient2 := tester2.dbClient
+		dbClient2.Truncate(t, &db.File{}, &db.FileTag{}, &db.FileCharacter{})
+
+		fileBuilder2 := tester2.newFileCreator(t)
+		fileBuilder2.CreateDirectory(image.Directory{ID: 1, Name: "Directory 1"})
+		fileBuilder2.CreateImage(image.ImageFile{ID: 11, Name: "image_file_11.jpg", ParentID: 1}, image.TestImageFileJpeg)
+		fileBuilder2.AddImageCreatedAt(11, time.Date(2021, 1, 1, 0, 0, 11, 0, time.UTC))
+
+		db.LoadTestData(t, dbClient2, []db.File{
+			fileBuilder2.BuildDBDirectory(1),
+			fileBuilder2.BuildDBImageFile(11),
+		})
+
+		// Make the parent directory read-only so os.Remove fails with EACCES.
+		dirPath := filepath.Join(tester2.config.ImageRootDirectory, "Directory 1")
+		require.NoError(t, os.Chmod(dirPath, 0555))
+		t.Cleanup(func() {
+			_ = os.Chmod(dirPath, 0755)
+		})
+
+		service := tester2.getImageService()
+		err := service.DeleteImages(context.Background(), []uint{11})
+		// DeleteImages is best-effort on disk removal, so it returns nil.
+		assert.NoError(t, err)
+
+		// Verify file is removed from DB even though disk removal failed.
+		remainingFiles, err := dbClient2.Client.File().FindImageFilesByIDs([]uint{11})
 		require.NoError(t, err)
 		assert.Empty(t, remainingFiles)
 	})

--- a/internal/image/resizer_test.go
+++ b/internal/image/resizer_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"image"
 	"image/color"
+	"image/gif"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -122,6 +123,22 @@ func TestResizer_ResizeImage(t *testing.T) {
 
 		_, err = resizer.ResizeImage(ctx, filePath, 100)
 		assert.Error(t, err)
+	})
+
+	t.Run("decodable format without encoder returns error", func(t *testing.T) {
+		// GIF is registered as a decoder (via import "image/gif" in this test file)
+		// but the Resizer only has encoders for jpeg and png.
+		tmpDir := t.TempDir()
+		filePath := filepath.Join(tmpDir, "test.gif")
+		img := image.NewPaletted(image.Rect(0, 0, 10, 10), color.Palette{color.White, color.Black})
+		f, err := os.Create(filePath)
+		require.NoError(t, err)
+		require.NoError(t, gif.Encode(f, img, nil))
+		require.NoError(t, f.Close())
+
+		_, err = resizer.ResizeImage(ctx, filePath, 5)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported image format for an encoder")
 	})
 }
 

--- a/internal/image/resizer_test.go
+++ b/internal/image/resizer_test.go
@@ -31,8 +31,8 @@ func createTestJPEGFile(t *testing.T, dir string, name string, width, height int
 	t.Helper()
 	filePath := filepath.Join(dir, name)
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
+	for y := range height {
+		for x := range width {
 			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 100, A: 255})
 		}
 	}
@@ -47,8 +47,8 @@ func createTestPNGFile(t *testing.T, dir string, name string, width, height int)
 	t.Helper()
 	filePath := filepath.Join(dir, name)
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
-	for y := 0; y < height; y++ {
-		for x := 0; x < width; x++ {
+	for y := range height {
+		for x := range width {
 			img.Set(x, y, color.RGBA{R: uint8(x % 256), G: uint8(y % 256), B: 200, A: 255})
 		}
 	}
@@ -144,8 +144,8 @@ func TestResizer_ResizeImage(t *testing.T) {
 
 func TestJpegEncoder_Encode(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
-	for y := 0; y < 10; y++ {
-		for x := 0; x < 10; x++ {
+	for y := range 10 {
+		for x := range 10 {
 			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
 		}
 	}
@@ -167,8 +167,8 @@ func TestJpegEncoder_Encode(t *testing.T) {
 
 func TestPngEncoder_Encode(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
-	for y := 0; y < 10; y++ {
-		for x := 0; x < 10; x++ {
+	for y := range 10 {
+		for x := range 10 {
 			img.Set(x, y, color.RGBA{R: 0, G: 255, B: 0, A: 255})
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func runMain(conf config.Config, logger *slog.Logger) error {
 	directoryReader := image.NewDirectoryReader(conf, dbClient)
 	tagReader := tag.NewReader(dbClient, directoryReader)
 	imageReader := image.NewReader(dbClient, directoryReader, imageFileConverter)
-	imageService := frontend.NewImageService(imageReader)
+	imageService := frontend.NewImageService(imageReader, dbClient)
 	directoryService := frontend.NewDirectoryService(
 		dbClient,
 		directoryReader,


### PR DESCRIPTION
## Summary
- Add option to delete selected images with confirmation dialog (backend `DeleteImages` + frontend "Delete" button in selection action bar)
- Restore backup configuration UI in settings: retention count, idle backup toggle, idle minutes, include images in idle backups
- Add "Include images" toggle for manual backup creation (was hardcoded to database-only)
- Update README to reflect the redesigned UI and current feature set

## Test plan
- [ ] Select images in anime detail or search page, click Delete, confirm → images removed from grid and disk
- [ ] Cancel the confirmation dialog → no deletion occurs
- [ ] Open Settings > Backup → verify configuration controls are visible and saveable
- [ ] Toggle "Include images" next to Create Backup, create backup → verify backup shows "Includes images"
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)